### PR TITLE
Add Discord social login

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This application is deployed on Railway. See [Deployment Guide](docs/DEPLOYMENT.
 ### User System
 - Registration and authentication
 - JWT-based secure login
+- Discord social login via Supabase
 - Cash balance management
 - Admin privileges for system management
 

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -9,7 +9,7 @@ const Login = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { signIn } = useAuth();
+  const { signInWithProvider } = useAuth();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -24,6 +24,18 @@ const Login = () => {
       console.error('Login error:', error);
       setError(error.message || 'Login failed. Please try again.');
     } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDiscordLogin = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await signInWithProvider('discord');
+    } catch (error) {
+      console.error('Discord login error:', error);
+      setError(error.message || 'Login failed. Please try again.');
       setLoading(false);
     }
   };
@@ -55,6 +67,9 @@ const Login = () => {
         </div>
         <button type="submit" className="btn" disabled={loading}>
           {loading ? 'Logging in...' : 'Login'}
+        </button>
+        <button type="button" className="btn" onClick={handleDiscordLogin} disabled={loading} style={{ marginTop: '10px' }}>
+          {loading ? 'Redirecting...' : 'Login with Discord'}
         </button>
       </form>
       <p>

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -11,7 +11,7 @@ const Register = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { signUp, signIn } = useAuth();
+  const { signInWithProvider } = useAuth();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -40,6 +40,18 @@ const Register = () => {
       console.error('Registration error:', error);
       setError(error.message || 'Registration failed. Please try again.');
     } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDiscordRegister = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await signInWithProvider('discord');
+    } catch (error) {
+      console.error('Discord registration error:', error);
+      setError(error.message || 'Registration failed. Please try again.');
       setLoading(false);
     }
   };
@@ -91,6 +103,9 @@ const Register = () => {
         </div>
         <button type="submit" className="btn" disabled={loading}>
           {loading ? 'Creating Account...' : 'Register'}
+        </button>
+        <button type="button" className="btn" onClick={handleDiscordRegister} disabled={loading} style={{ marginTop: '10px' }}>
+          {loading ? 'Redirecting...' : 'Register with Discord'}
         </button>
       </form>
       <p>


### PR DESCRIPTION
## Summary
- allow signing in or registering with Discord via Supabase OAuth
- mention Discord login in the user system section of the README

## Testing
- `npm ci` *(installs frontend dependencies)*
- `REACT_APP_SUPABASE_URL=http://localhost REACT_APP_SUPABASE_ANON_KEY=dummy npm run test:ci` *(fails: useTheme must be used within a ThemeProvider)*

------
https://chatgpt.com/codex/tasks/task_e_6888f39fbc288331af7463e95d26b610