### PR TITLE
Improve token handling and deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ MYSQLDATABASE=railway
 
 # Authentication
 JWT_SECRET=your-secret-jwt-key
+# IMPORTANT: Use the same value for every deployment so existing JWTs remain valid
 
 # Server
 PORT=8080

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ docker-compose up
 
 This application is deployed on Railway. See [Deployment Guide](docs/DEPLOYMENT.md) for detailed deployment instructions.
 
+### Environment variables
+
+Set a `JWT_SECRET` environment variable in Railway and **keep this value the same for all deployments**. If the secret changes, previously issued JWTs will be rejected and users will be forced to log in again.
+
+The frontend detects `401` or `403` responses and will attempt to resynchronize authentication automatically. If it cannot obtain a new token, the user is redirected to the login page.
+
 ## Features
 
 ### Stock Trading

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This application is deployed on Railway. See [Deployment Guide](docs/DEPLOYMENT.
 
 Set a `JWT_SECRET` environment variable in Railway and **keep this value the same for all deployments**. If the secret changes, previously issued JWTs will be rejected and users will be forced to log in again.
 
-The frontend detects `401` or `403` responses and will attempt to resynchronize authentication automatically. If it cannot obtain a new token, the user is redirected to the login page.
+The frontend automatically clears stale credentials when it receives a `401` or `403` response and tries to resynchronize using the current Supabase session. Only if that refresh fails will the user be redirected to the login page.
 
 ## Features
 

--- a/frontend/src/services/authBridge.js
+++ b/frontend/src/services/authBridge.js
@@ -59,8 +59,10 @@ export const getAuthToken = async () => {
 }
 
 // Enhanced fetch that includes proper authentication
+let syncPromise = null
+
 export const authenticatedFetch = async (url, options = {}) => {
-  const token = await getAuthToken()
+  let token = await getAuthToken()
 
   if (!token) {
     throw new Error('No authentication token available')
@@ -71,7 +73,7 @@ export const authenticatedFetch = async (url, options = {}) => {
     'Authorization': `Bearer ${token}`
   }
 
-  const response = await fetch(url, {
+  let response = await fetch(url, {
     ...options,
     headers,
     credentials: 'include'
@@ -85,26 +87,37 @@ export const authenticatedFetch = async (url, options = {}) => {
     localStorage.removeItem('isAdmin')
 
     try {
-      // Attempt to resync auth from Supabase session
-      await syncAuthWithBackend()
-      const retryToken = await getAuthToken()
-      if (retryToken) {
+      // Attempt to resync auth from Supabase session (deduplicated)
+      if (!syncPromise) {
+        syncPromise = syncAuthWithBackend().finally(() => { syncPromise = null })
+      }
+      await syncPromise
+
+      token = await getAuthToken()
+      if (token) {
         const retryHeaders = {
           ...options.headers,
-          'Authorization': `Bearer ${retryToken}`
+          'Authorization': `Bearer ${token}`
         }
-        return fetch(url, {
+        response = await fetch(url, {
           ...options,
           headers: retryHeaders,
           credentials: 'include'
         })
+
+        if (response.ok) {
+          return response
+        }
       }
     } catch (err) {
       console.error('Auth resync failed:', err)
     }
 
     // Redirect to login if we still have no valid token
-    window.location.href = '/login'
+    if (!window.location.pathname.includes('/login')) {
+      window.location.href = '/login'
+    }
+    return Promise.reject(new Error('Authentication failed - redirecting to login'))
   }
 
   return response

--- a/frontend/src/services/authBridge.js
+++ b/frontend/src/services/authBridge.js
@@ -61,7 +61,7 @@ export const getAuthToken = async () => {
 // Enhanced fetch that includes proper authentication
 export const authenticatedFetch = async (url, options = {}) => {
   const token = await getAuthToken()
-  
+
   if (!token) {
     throw new Error('No authentication token available')
   }
@@ -71,9 +71,41 @@ export const authenticatedFetch = async (url, options = {}) => {
     'Authorization': `Bearer ${token}`
   }
 
-  return fetch(url, {
+  const response = await fetch(url, {
     ...options,
     headers,
     credentials: 'include'
   })
+
+  if (response.status === 401 || response.status === 403) {
+    // Token might be invalid or expired - clear stored credentials
+    localStorage.removeItem('token')
+    localStorage.removeItem('userId')
+    localStorage.removeItem('username')
+    localStorage.removeItem('isAdmin')
+
+    try {
+      // Attempt to resync auth from Supabase session
+      await syncAuthWithBackend()
+      const retryToken = await getAuthToken()
+      if (retryToken) {
+        const retryHeaders = {
+          ...options.headers,
+          'Authorization': `Bearer ${retryToken}`
+        }
+        return fetch(url, {
+          ...options,
+          headers: retryHeaders,
+          credentials: 'include'
+        })
+      }
+    } catch (err) {
+      console.error('Auth resync failed:', err)
+    }
+
+    // Redirect to login if we still have no valid token
+    window.location.href = '/login'
+  }
+
+  return response
 }

--- a/railway.env.sample
+++ b/railway.env.sample
@@ -22,6 +22,7 @@ ALT_DB_NAME=railway
 # Application configuration
 PORT=8080
 JWT_SECRET=your-jwt-secret-key
+# IMPORTANT: keep this secret consistent across deployments
 
 # Supabase configuration (optional - for Discord OAuth)
 SUPABASE_PROJECT_REF=your-supabase-project-id


### PR DESCRIPTION
## Summary
- enhance `authenticatedFetch` to refresh on 401/403 and redirect if refresh fails
- document JWT_SECRET persistence and auto token refresh in README
- note JWT secret persistence in example env files

## Testing
- `npm install` and `npm test -- --watchAll=false` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6889348000c88331b07928d268ea9337