### PR TITLE
Add beta Discord OAuth helper

### DIFF
--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -2,11 +2,12 @@ import React, { createContext, useContext, useEffect, useState } from 'react'
 import { 
   signUp, 
   signIn, 
-  signOut, 
-  getCurrentUser, 
-  getCurrentSession, 
+  signOut,
+  getCurrentUser,
+  getCurrentSession,
   onAuthStateChange,
-  signInWithProvider 
+  signInWithProvider,
+  signInWithDiscordBeta
 } from '../services/supabaseAuth'
 import { syncAuthWithBackend } from '../services/authBridge'
 
@@ -17,7 +18,8 @@ const AuthContext = createContext({
   signUp: () => {},
   signIn: () => {},
   signOut: () => {},
-  signInWithProvider: () => {}
+  signInWithProvider: () => {},
+  signInWithDiscordBeta: () => {}
 })
 
 export const useAuth = () => {
@@ -113,6 +115,15 @@ export const AuthProvider = ({ children }) => {
     }
   }
 
+  const handleSignInWithDiscordBeta = async () => {
+    try {
+      const result = await signInWithDiscordBeta()
+      return result
+    } catch (error) {
+      throw error
+    }
+  }
+
   const value = {
     user,
     session,
@@ -120,7 +131,8 @@ export const AuthProvider = ({ children }) => {
     signUp: handleSignUp,
     signIn: handleSignIn,
     signOut: handleSignOut,
-    signInWithProvider: handleSignInWithProvider
+    signInWithProvider: handleSignInWithProvider,
+    signInWithDiscordBeta: handleSignInWithDiscordBeta
   }
 
   return (

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -9,7 +9,7 @@ const Login = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { signInWithProvider } = useAuth();
+  const { signInWithDiscordBeta } = useAuth();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -32,7 +32,7 @@ const Login = () => {
     setError('');
     setLoading(true);
     try {
-      await signInWithProvider('discord');
+      await signInWithDiscordBeta();
     } catch (error) {
       console.error('Discord login error:', error);
       setError(error.message || 'Login failed. Please try again.');

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -11,7 +11,7 @@ const Register = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { signInWithProvider } = useAuth();
+  const { signInWithDiscordBeta } = useAuth();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -48,7 +48,7 @@ const Register = () => {
     setError('');
     setLoading(true);
     try {
-      await signInWithProvider('discord');
+      await signInWithDiscordBeta();
     } catch (error) {
       console.error('Discord registration error:', error);
       setError(error.message || 'Registration failed. Please try again.');

--- a/frontend/src/services/supabaseAuth.js
+++ b/frontend/src/services/supabaseAuth.js
@@ -143,6 +143,23 @@ export const signInWithProvider = async (provider) => {
   }
 }
 
+// Discord sign in for beta with fixed redirect URL
+export const signInWithDiscordBeta = async () => {
+  try {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'discord',
+      options: {
+        redirectTo: 'https://beta.officestonks.com/dashboard'
+      }
+    })
+    if (error) throw error
+    return data
+  } catch (error) {
+    console.error('Discord beta sign in error:', error)
+    throw error
+  }
+}
+
 // Auth state change listener
 export const onAuthStateChange = (callback) => {
   return supabase.auth.onAuthStateChange(callback)


### PR DESCRIPTION
## Summary
- add `signInWithDiscordBeta` to call Supabase with fixed beta redirect
- expose `signInWithDiscordBeta` via auth context
- update login and register pages to use new helper

## Testing
- `npm run test:ci` *(fails: Missing Supabase env vars and component test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68897da372008331ae5248fc0a273b4f