### PR TITLE
Add audit log and refresh loading fix

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -84,6 +84,7 @@ func main() {
 	newsRepo := repository.NewNewsRepo(db)
 	sectorRepo := repository.NewSectorRepo(db)
 	changelogRepo := repository.NewChangelogRepo(db)
+	auditRepo := repository.NewAuditRepo(db)
 	// TODO: Will be used for crisis/bankruptcy mechanics
 	// delistedStockRepo := repository.NewDelistedStockRepo(db)
 	// portfolioLossRepo := repository.NewPortfolioLossRepo(db)
@@ -115,18 +116,20 @@ func main() {
 	chatService := services.NewChatService(chatRepo, userRepo, wsHub)
 	newsService := services.NewNewsService(newsRepo)
 	changelogService := services.NewChangelogService(changelogRepo)
+	auditService := services.NewAuditService(auditRepo)
 
 	// Create websocket handler
 	wsHandler := websocket.NewWebSocketHandler(wsHub, authService)
 
 	// Create handlers
-	authHandler := handlers.NewAuthHandler(authService)
+	authHandler := handlers.NewAuthHandler(authService, auditService)
 	marketHandler := handlers.NewMarketHandler(marketService)
 	userHandler := handlers.NewUserHandler(userService)
 	chatHandler := handlers.NewChatHandler(chatService)
 	adminHandler := handlers.NewAdminHandler(userRepo, stockRepo, chatRepo, marketService)
 	newsHandler := handlers.NewNewsHandler(newsService)
 	changelogHandler := handlers.NewChangelogHandler(changelogService)
+	auditHandler := handlers.NewAuditHandler(auditService)
 	gameConfigHandler := handlers.NewGameConfigHandler()
 
 	// Create middleware
@@ -223,7 +226,7 @@ func main() {
 	authRouter.HandleFunc("/debug/supabase", authHandler.DebugSupabaseConfig).Methods("GET", "OPTIONS")
 	authRouter.HandleFunc("/check-username", authHandler.CheckUsernameAvailability).Methods("POST", "OPTIONS")
 	authRouter.HandleFunc("/version", authHandler.GetVersion).Methods("GET", "OPTIONS")
-	
+
 	// Protected auth routes
 	protectedAuthRouter := authRouter.PathPrefix("").Subrouter()
 	protectedAuthRouter.Use(authMiddleware.Authenticate)
@@ -235,7 +238,7 @@ func main() {
 
 	// Public user routes
 	apiRouter.HandleFunc("/users/leaderboard", userHandler.GetLeaderboard).Methods("GET", "OPTIONS")
-	
+
 	// Public changelog routes
 	apiRouter.HandleFunc("/changelog", changelogHandler.GetPublicChangelog).Methods("GET", "OPTIONS")
 	apiRouter.HandleFunc("/changelog/{version}", changelogHandler.GetChangelogByVersion).Methods("GET", "OPTIONS")
@@ -301,6 +304,9 @@ func main() {
 	adminRouter.HandleFunc("/changelog", changelogHandler.CreateChangelog).Methods("POST", "OPTIONS")
 	adminRouter.HandleFunc("/changelog/{id:[0-9]+}/visibility", changelogHandler.UpdateChangelogVisibility).Methods("PUT", "OPTIONS")
 	adminRouter.HandleFunc("/changelog/{id:[0-9]+}", changelogHandler.DeleteChangelog).Methods("DELETE", "OPTIONS")
+
+	// Audit log
+	adminRouter.HandleFunc("/audit", auditHandler.GetRecentEvents).Methods("GET", "OPTIONS")
 
 	// WebSocket route with explicit OPTIONS handling
 	r.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
@@ -420,11 +426,11 @@ func main() {
 	// Emergency stock price reset endpoint (no auth required - for fixing infinity errors)
 	apiRouter.HandleFunc("/emergency/reset-stocks", func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Emergency stock price reset called")
-		
+
 		// Set CORS headers
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		// Reset stock prices
 		stocks, err := stockRepo.GetAllStocks()
 		if err != nil {
@@ -434,28 +440,28 @@ func main() {
 		}
 
 		log.Printf("Emergency reset: Found %d stocks to reset", len(stocks))
-		
+
 		for _, stock := range stocks {
 			// Generate a new random price between $1 and $1000
 			newPrice := 1.0 + (rand.Float64() * 999.0)
-			
+
 			err = stockRepo.UpdateStockPrice(stock.ID, newPrice)
 			if err != nil {
 				log.Printf("Emergency reset: Failed to update %s: %v", stock.Symbol, err)
 				continue
 			}
-			
+
 			log.Printf("Emergency reset: Updated %s to $%.2f", stock.Symbol, newPrice)
 		}
-		
+
 		// Validate market simulator
 		log.Println("Emergency reset: Validating market simulator...")
 		marketService.ValidateSimulator()
-		
+
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"success": true,
-			"message": "Emergency stock reset completed",
+			"success":      true,
+			"message":      "Emergency stock reset completed",
 			"stocks_reset": len(stocks),
 		})
 	}).Methods("GET", "POST", "OPTIONS")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import StockDetail from './pages/StockDetail';
 import Leaderboard from './pages/Leaderboard';
 import Transactions from './pages/Transactions';
 import AdminPanel from './pages/AdminPanel';
+import AuditLog from './pages/AuditLog';
 import Portfolio from './pages/Portfolio';
 import ProtectedRoute from './components/ProtectedRoute';
 import AuthSync from './components/AuthSync';
@@ -41,6 +42,7 @@ const AppContent = () => {
             <Route path="/leaderboard" element={<ProtectedRoute element={<Leaderboard />} />} />
             <Route path="/transactions" element={<ProtectedRoute element={<Transactions />} />} />
             <Route path="/admin" element={<ProtectedRoute element={<AdminPanel />} />} />
+            <Route path="/audit" element={<ProtectedRoute element={<AuditLog />} />} />
 
             {/* Default redirect */}
             <Route path="*" element={<Navigate to="/login" />} />

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -60,6 +60,11 @@ const Navigation = () => {
               </Link>
             </li>
           )}
+          {isAdmin && (
+            <li>
+              <Link to="/audit" className="admin-link">Audit Log</Link>
+            </li>
+          )}
           <li>
             <button onClick={() => {
               console.log('Changelog button clicked');

--- a/frontend/src/components/Navigation.test.js
+++ b/frontend/src/components/Navigation.test.js
@@ -2,7 +2,20 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import Navigation from './Navigation';
+import { ChangelogProvider } from '../contexts/ChangelogContext';
+import { ThemeProvider } from '../contexts/ThemeContext';
 import * as authService from '../services/auth';
+
+// Provide matchMedia mock for ThemeProvider
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    });
+  }
+});
 
 // Mock the auth service
 jest.mock('../services/auth', () => ({
@@ -24,7 +37,11 @@ describe('Navigation Component', () => {
   test('renders all navigation links', () => {
     render(
       <BrowserRouter>
-        <Navigation />
+        <ThemeProvider>
+          <ChangelogProvider>
+            <Navigation />
+          </ChangelogProvider>
+        </ThemeProvider>
       </BrowserRouter>
     );
 
@@ -40,7 +57,11 @@ describe('Navigation Component', () => {
   test('calls logout when logout button is clicked', () => {
     render(
       <BrowserRouter>
-        <Navigation />
+        <ThemeProvider>
+          <ChangelogProvider>
+            <Navigation />
+          </ChangelogProvider>
+        </ThemeProvider>
       </BrowserRouter>
     );
 

--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -76,6 +76,13 @@ export const AuthProvider = ({ children }) => {
     }
   }, [])
 
+  // Fallback loading timeout in case auth checks hang
+  useEffect(() => {
+    if (!loading) return
+    const timer = setTimeout(() => setLoading(false), 5000)
+    return () => clearTimeout(timer)
+  }, [loading])
+
   const handleSignUp = async (email, password, userData = {}) => {
     try {
       const result = await signUp(email, password, userData)
@@ -117,6 +124,7 @@ export const AuthProvider = ({ children }) => {
     user,
     session,
     loading,
+    isAuthenticated: !!user,
     signUp: handleSignUp,
     signIn: handleSignIn,
     signOut: handleSignOut,

--- a/frontend/src/pages/AuditLog.js
+++ b/frontend/src/pages/AuditLog.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import Navigation from '../components/Navigation';
+import { authenticatedFetch } from '../services/authBridge';
+import './AdminPanel.css';
+
+const AuditLog = () => {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      try {
+        const res = await authenticatedFetch('/api/admin/audit?limit=100');
+        if (!res.ok) throw new Error('Failed to fetch audit log');
+        const data = await res.json();
+        setEvents(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error('Audit log fetch error:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchEvents();
+  }, []);
+
+  return (
+    <div className="admin-panel-page">
+      <Navigation />
+      <div className="admin-panel-container">
+        <h1>Audit Log</h1>
+        {loading ? (
+          <div>Loading...</div>
+        ) : (
+          <table className="users-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>User ID</th>
+                <th>Action</th>
+                <th>IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map(evt => (
+                <tr key={evt.id}>
+                  <td>{new Date(evt.created_at).toLocaleString()}</td>
+                  <td>{evt.user_id}</td>
+                  <td>{evt.action}</td>
+                  <td>{evt.ip_address || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AuditLog;

--- a/frontend/src/pages/Login.test.js
+++ b/frontend/src/pages/Login.test.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import Login from './Login';
-import * as authService from '../services/auth';
+import * as workaround from '../services/supabaseWorkaround';
 
 // Mock the auth service
-jest.mock('../services/auth', () => ({
-  login: jest.fn(),
+jest.mock('../services/supabaseWorkaround', () => ({
+  loginWithWorkaround: jest.fn(),
 }));
 
 // Mock the useNavigate hook
@@ -30,16 +30,16 @@ describe('Login Component', () => {
 
     // Check that the form elements are rendered
     expect(screen.getByText('Login to Office Stonks')).toBeInTheDocument();
-    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument();
     expect(screen.getByText('Don\'t have an account?')).toBeInTheDocument();
     expect(screen.getByText('Register')).toBeInTheDocument();
   });
 
-  test('submits form with username and password', async () => {
+  test('submits form with email and password', async () => {
     // Mock successful login
-    authService.login.mockResolvedValueOnce({ token: 'test-token', user_id: 1 });
+    workaround.loginWithWorkaround.mockResolvedValueOnce({ user: {}, session: {} });
 
     render(
       <BrowserRouter>
@@ -48,24 +48,24 @@ describe('Login Component', () => {
     );
 
     // Fill in form fields
-    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'testuser' } });
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
 
     // Submit the form
     fireEvent.click(screen.getByRole('button', { name: 'Login' }));
 
     // Check that login was called with correct arguments
-    expect(authService.login).toHaveBeenCalledWith('testuser', 'password123');
+    expect(workaround.loginWithWorkaround).toHaveBeenCalledWith('test@example.com', 'password123');
 
     // Wait for login to complete
     await waitFor(() => {
-      expect(authService.login).toHaveBeenCalled();
+      expect(workaround.loginWithWorkaround).toHaveBeenCalled();
     });
   });
 
   test('displays error message when login fails', async () => {
     // Mock failed login
-    authService.login.mockRejectedValueOnce(new Error('Invalid credentials'));
+    workaround.loginWithWorkaround.mockRejectedValueOnce(new Error('Invalid credentials'));
 
     render(
       <BrowserRouter>
@@ -74,7 +74,7 @@ describe('Login Component', () => {
     );
 
     // Fill in form fields
-    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'testuser' } });
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrongpassword' } });
 
     // Submit the form
@@ -88,8 +88,8 @@ describe('Login Component', () => {
 
   test('disables form submission while loading', async () => {
     // Mock login that takes time to resolve
-    authService.login.mockImplementationOnce(() => new Promise(resolve => {
-      setTimeout(() => resolve({ token: 'test-token', user_id: 1 }), 100);
+    workaround.loginWithWorkaround.mockImplementationOnce(() => new Promise(resolve => {
+      setTimeout(() => resolve({ user: {}, session: {} }), 100);
     }));
 
     render(
@@ -99,7 +99,7 @@ describe('Login Component', () => {
     );
 
     // Fill in form fields
-    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'testuser' } });
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'test@example.com' } });
     fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
 
     // Submit the form
@@ -111,7 +111,7 @@ describe('Login Component', () => {
 
     // Wait for login to complete
     await waitFor(() => {
-      expect(authService.login).toHaveBeenCalled();
+      expect(workaround.loginWithWorkaround).toHaveBeenCalled();
     });
   });
 });

--- a/internal/handlers/audit_handler.go
+++ b/internal/handlers/audit_handler.go
@@ -22,6 +22,9 @@ func (h *AuditHandler) GetRecentEvents(w http.ResponseWriter, r *http.Request) {
 	limitStr := r.URL.Query().Get("limit")
 	limit := 20
 	if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+		if l > 1000 {
+			l = 1000
+		}
 		limit = l
 	}
 	events, err := h.service.GetRecentEvents(limit)

--- a/internal/handlers/audit_handler.go
+++ b/internal/handlers/audit_handler.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"officestonks/internal/services"
+)
+
+// AuditHandler exposes audit log endpoints
+type AuditHandler struct {
+	service *services.AuditService
+}
+
+func NewAuditHandler(service *services.AuditService) *AuditHandler {
+	return &AuditHandler{service: service}
+}
+
+// GetRecentEvents returns recent audit log entries (admin only)
+func (h *AuditHandler) GetRecentEvents(w http.ResponseWriter, r *http.Request) {
+	limitStr := r.URL.Query().Get("limit")
+	limit := 20
+	if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+		limit = l
+	}
+	events, err := h.service.GetRecentEvents(limit)
+	if err != nil {
+		http.Error(w, "Failed to fetch audit log", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(events)
+}

--- a/internal/handlers/auth_handler.go
+++ b/internal/handlers/auth_handler.go
@@ -16,13 +16,15 @@ import (
 
 // AuthHandler handles authentication requests
 type AuthHandler struct {
-	authService *services.AuthService
+	authService  *services.AuthService
+	auditService *services.AuditService
 }
 
 // NewAuthHandler creates a new authentication handler
-func NewAuthHandler(authService *services.AuthService) *AuthHandler {
+func NewAuthHandler(authService *services.AuthService, auditService *services.AuditService) *AuthHandler {
 	return &AuthHandler{
-		authService: authService,
+		authService:  authService,
+		auditService: auditService,
 	}
 }
 
@@ -52,6 +54,11 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Error registering user", http.StatusInternalServerError)
 		}
 		return
+	}
+
+	if h.auditService != nil {
+		ip := strings.Split(r.RemoteAddr, ":")[0]
+		_ = h.auditService.LogEvent(resp.UserID, "login", ip)
 	}
 
 	// Return response
@@ -162,15 +169,15 @@ func (h *AuthHandler) DebugSupabaseConfig(w http.ResponseWriter, r *http.Request
 	if projectRef != "" {
 		jwksURL = fmt.Sprintf("https://%s.supabase.co/auth/v1/.well-known/jwks.json", projectRef)
 	}
-	
+
 	debug := map[string]interface{}{
-		"supabase_enabled":    auth.IsSupabaseEnabled(),
-		"has_project_ref":     projectRef != "",
-		"project_ref":         projectRef,
-		"project_ref_length":  len(projectRef),
+		"supabase_enabled":   auth.IsSupabaseEnabled(),
+		"has_project_ref":    projectRef != "",
+		"project_ref":        projectRef,
+		"project_ref_length": len(projectRef),
 		"jwks_url":           jwksURL,
 	}
-	
+
 	// Test JWKS URL if available
 	if jwksURL != "" {
 		resp, err := http.Get(jwksURL)
@@ -215,8 +222,8 @@ func (h *AuthHandler) CheckUsernameAvailability(w http.ResponseWriter, r *http.R
 
 	// Check if username contains only allowed characters (alphanumeric and underscore)
 	for _, char := range req.Username {
-		if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || 
-			 (char >= '0' && char <= '9') || char == '_') {
+		if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '_') {
 			response := map[string]interface{}{
 				"available": false,
 				"error":     "Username can only contain letters, numbers, and underscores",
@@ -278,8 +285,8 @@ func (h *AuthHandler) SetUsername(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, char := range req.Username {
-		if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || 
-			 (char >= '0' && char <= '9') || char == '_') {
+		if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '_') {
 			http.Error(w, "Username can only contain letters, numbers, and underscores", http.StatusBadRequest)
 			return
 		}

--- a/internal/handlers/auth_handler.go
+++ b/internal/handlers/auth_handler.go
@@ -73,7 +73,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 
 	if h.auditService != nil {
 		ip := getClientIP(r)
-		_ = h.auditService.LogEvent(resp.UserID, "login", ip)
+		_ = h.auditService.LogEvent(resp.UserID, "register", ip)
 	}
 
 	// Return response

--- a/internal/handlers/auth_handler.go
+++ b/internal/handlers/auth_handler.go
@@ -14,6 +14,21 @@ import (
 	"officestonks/internal/services"
 )
 
+// getClientIP attempts to determine the real client IP address accounting for
+// reverse proxies and load balancers.
+func getClientIP(r *http.Request) string {
+	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+		parts := strings.Split(forwarded, ",")
+		if len(parts) > 0 {
+			return strings.TrimSpace(parts[0])
+		}
+	}
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		return realIP
+	}
+	return strings.Split(r.RemoteAddr, ":")[0]
+}
+
 // AuthHandler handles authentication requests
 type AuthHandler struct {
 	authService  *services.AuthService
@@ -57,7 +72,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.auditService != nil {
-		ip := strings.Split(r.RemoteAddr, ":")[0]
+		ip := getClientIP(r)
 		_ = h.auditService.LogEvent(resp.UserID, "login", ip)
 	}
 
@@ -87,6 +102,11 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error logging in user: %v", err)
 		http.Error(w, "Invalid username or password", http.StatusUnauthorized)
 		return
+	}
+
+	if h.auditService != nil {
+		ip := getClientIP(r)
+		_ = h.auditService.LogEvent(resp.UserID, "login", ip)
 	}
 
 	// Return response

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+// AuditEvent represents a single audit log entry
+type AuditEvent struct {
+	ID        int       `json:"id"`
+	UserID    int       `json:"user_id"`
+	Action    string    `json:"action"`
+	IPAddress string    `json:"ip_address"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// AuditLogRepository defines persistence methods for audit events
+type AuditLogRepository interface {
+	LogEvent(userID int, action, ipAddress string) error
+	GetRecentEvents(limit int) ([]*AuditEvent, error)
+}

--- a/internal/repository/audit_repository.go
+++ b/internal/repository/audit_repository.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	"database/sql"
+
+	"officestonks/internal/models"
+)
+
+// AuditRepo implements models.AuditLogRepository
+type AuditRepo struct {
+	db *sql.DB
+}
+
+// NewAuditRepo creates a new AuditRepo
+func NewAuditRepo(db *sql.DB) *AuditRepo {
+	return &AuditRepo{db: db}
+}
+
+// LogEvent inserts an audit log entry
+func (r *AuditRepo) LogEvent(userID int, action, ipAddress string) error {
+	query := `INSERT INTO audit_logs (user_id, action, ip_address) VALUES (?, ?, ?)`
+	_, err := RetryExec(r.db, query, userID, action, ipAddress)
+	return err
+}
+
+// GetRecentEvents returns the most recent audit events
+func (r *AuditRepo) GetRecentEvents(limit int) ([]*models.AuditEvent, error) {
+	query := `SELECT id, user_id, action, ip_address, created_at FROM audit_logs ORDER BY created_at DESC LIMIT ?`
+	rows, err := RetryQuery(r.db, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []*models.AuditEvent
+	for rows.Next() {
+		var evt models.AuditEvent
+		if err := rows.Scan(&evt.ID, &evt.UserID, &evt.Action, &evt.IPAddress, &evt.CreatedAt); err != nil {
+			return nil, err
+		}
+		events = append(events, &evt)
+	}
+	return events, nil
+}

--- a/internal/repository/schema.go
+++ b/internal/repository/schema.go
@@ -123,6 +123,16 @@ CREATE TABLE IF NOT EXISTS changelog (
   created_by INT NULL,
   FOREIGN KEY (created_by) REFERENCES users(id)
 );
+
+-- Audit Logs Table
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  user_id INT NOT NULL,
+  action VARCHAR(50) NOT NULL,
+  ip_address VARCHAR(45),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
 `
 
 // Initial seed data SQL

--- a/internal/services/audit_service.go
+++ b/internal/services/audit_service.go
@@ -1,0 +1,32 @@
+package services
+
+import "officestonks/internal/models"
+
+// AuditService provides audit logging operations
+type AuditService struct {
+	repo models.AuditLogRepository
+}
+
+// NewAuditService creates an AuditService
+func NewAuditService(repo models.AuditLogRepository) *AuditService {
+	return &AuditService{repo: repo}
+}
+
+// LogEvent records an audit event
+func (s *AuditService) LogEvent(userID int, action, ip string) error {
+	if s.repo == nil {
+		return nil
+	}
+	return s.repo.LogEvent(userID, action, ip)
+}
+
+// GetRecentEvents returns recent audit events
+func (s *AuditService) GetRecentEvents(limit int) ([]*models.AuditEvent, error) {
+	if s.repo == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	return s.repo.GetRecentEvents(limit)
+}

--- a/internal/services/audit_service.go
+++ b/internal/services/audit_service.go
@@ -1,6 +1,10 @@
 package services
 
-import "officestonks/internal/models"
+import (
+	"fmt"
+
+	"officestonks/internal/models"
+)
 
 // AuditService provides audit logging operations
 type AuditService struct {
@@ -15,7 +19,7 @@ func NewAuditService(repo models.AuditLogRepository) *AuditService {
 // LogEvent records an audit event
 func (s *AuditService) LogEvent(userID int, action, ip string) error {
 	if s.repo == nil {
-		return nil
+		return fmt.Errorf("audit repository not configured")
 	}
 	return s.repo.LogEvent(userID, action, ip)
 }
@@ -23,7 +27,7 @@ func (s *AuditService) LogEvent(userID int, action, ip string) error {
 // GetRecentEvents returns recent audit events
 func (s *AuditService) GetRecentEvents(limit int) ([]*models.AuditEvent, error) {
 	if s.repo == nil {
-		return nil, nil
+		return nil, fmt.Errorf("audit repository not configured")
 	}
 	if limit <= 0 {
 		limit = 20


### PR DESCRIPTION
## Summary
- add audit event model, repository and service
- log user login events
- expose audit log through new `/api/admin/audit` endpoint
- link to Audit Log page from navigation
- show Audit Log page
- add fallback timeout in auth context to avoid infinite loading
- include authentication status in context

## Testing
- `REACT_APP_SUPABASE_URL=http://localhost REACT_APP_SUPABASE_ANON_KEY=dummy npm run test:ci` *(fails: useChangelog must be used within a ChangelogProvider)*

------
https://chatgpt.com/codex/tasks/task_e_688a46c1f42483319ca6ceca48584cc3