### PR TITLE
Ensure stock price edits persist and balance simulator trends

### DIFF
--- a/internal/handlers/admin_handler.go
+++ b/internal/handlers/admin_handler.go
@@ -1,11 +1,11 @@
 package handlers
 
 import (
-	"officestonks/internal/middleware"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"officestonks/internal/middleware"
 	"strconv"
 	"strings"
 	"time"
@@ -31,7 +31,6 @@ func NewAdminHandler(userRepo models.UserRepository, stockRepo models.StockRepos
 		marketService: marketService,
 	}
 }
-
 
 // getUserIDFromContext extracts user ID from request context
 func getUserIDFromContext(r *http.Request) (int, bool) {
@@ -97,7 +96,6 @@ func (h *AdminHandler) AdminOnly(next http.HandlerFunc) http.HandlerFunc {
 			log.Printf("AdminOnly: Added token from URL parameter: %s", tokenPrefix)
 		}
 
-
 		// Get user ID from context (set by auth middleware)
 		userID, ok := getUserIDFromContext(r)
 		log.Printf("AdminOnly: UserID from context: %v, ok: %v", userID, ok)
@@ -108,10 +106,10 @@ func (h *AdminHandler) AdminOnly(next http.HandlerFunc) http.HandlerFunc {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			json.NewEncoder(w).Encode(map[string]string{
-				"error": "Unauthorized",
-				"message": "Authentication required for admin access",
-				"path": r.URL.Path,
-				"method": r.Method,
+				"error":     "Unauthorized",
+				"message":   "Authentication required for admin access",
+				"path":      r.URL.Path,
+				"method":    r.Method,
 				"has_token": fmt.Sprintf("%t", r.Header.Get("Authorization") != ""),
 			})
 			return
@@ -126,7 +124,7 @@ func (h *AdminHandler) AdminOnly(next http.HandlerFunc) http.HandlerFunc {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{
-				"error": "Internal Server Error",
+				"error":   "Internal Server Error",
 				"message": "Error checking admin status",
 			})
 			return
@@ -137,7 +135,7 @@ func (h *AdminHandler) AdminOnly(next http.HandlerFunc) http.HandlerFunc {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			json.NewEncoder(w).Encode(map[string]string{
-				"error": "Forbidden",
+				"error":   "Forbidden",
 				"message": "Admin access required",
 				"user_id": fmt.Sprintf("%d", userID),
 			})
@@ -192,7 +190,6 @@ func (h *AdminHandler) GetAdminStatus(w http.ResponseWriter, r *http.Request) {
 		log.Printf("GetAdminStatus: Found token in URL: %s", tokenPrefix)
 	}
 
-
 	// Get user ID from context (set by auth middleware)
 	userID, ok := getUserIDFromContext(r)
 	log.Printf("GetAdminStatus: userID from context: %v, ok: %v", userID, ok)
@@ -202,7 +199,7 @@ func (h *AdminHandler) GetAdminStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{
-			"error": "Unauthorized",
+			"error":   "Unauthorized",
 			"message": "Authentication required",
 		})
 		return
@@ -217,7 +214,7 @@ func (h *AdminHandler) GetAdminStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{
-			"error": "Internal Server Error",
+			"error":   "Internal Server Error",
 			"message": "Error checking admin status",
 		})
 		return
@@ -283,7 +280,7 @@ func (h *AdminHandler) GetAllUsers(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{
-			"error": "Internal Server Error",
+			"error":   "Internal Server Error",
 			"message": "Error retrieving users",
 		})
 		return
@@ -501,9 +498,9 @@ func (h *AdminHandler) ResetStockPrices(w http.ResponseWriter, r *http.Request) 
 	h.marketService.ValidateSimulator()
 
 	response := map[string]interface{}{
-		"message": "Stock prices reset and market simulator reinitialized successfully",
-		"success": true,
-		"timestamp": time.Now().String(),
+		"message":      "Stock prices reset and market simulator reinitialized successfully",
+		"success":      true,
+		"timestamp":    time.Now().String(),
 		"stocks_count": len(stocks),
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -549,8 +546,8 @@ func (h *AdminHandler) ClearAllChats(w http.ResponseWriter, r *http.Request) {
 
 	// Return success
 	response := map[string]interface{}{
-		"message": "Chat messages cleared successfully",
-		"success": true,
+		"message":   "Chat messages cleared successfully",
+		"success":   true,
 		"timestamp": time.Now().String(),
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -563,34 +560,34 @@ func (h *AdminHandler) ClearAllChats(w http.ResponseWriter, r *http.Request) {
 func (h *AdminHandler) ForceCrisisEvent(w http.ResponseWriter, r *http.Request) {
 	// Set CORS headers
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	// Parse request body
 	var req struct {
 		StockID int `json:"stock_id"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	
+
 	if req.StockID <= 0 {
 		http.Error(w, "Invalid stock ID", http.StatusBadRequest)
 		return
 	}
-	
+
 	log.Printf("🧪 Admin forcing crisis event for stock ID: %d", req.StockID)
-	
+
 	// Force crisis event
 	err := h.marketService.ForceCrisisEvent(req.StockID)
 	if err != nil {
@@ -598,14 +595,14 @@ func (h *AdminHandler) ForceCrisisEvent(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, fmt.Sprintf("Error forcing crisis: %v", err), http.StatusInternalServerError)
 		return
 	}
-	
+
 	// Get stock info after crisis
 	stockInfo, err := h.marketService.GetSimulatorStockInfo(req.StockID)
 	if err != nil {
 		log.Printf("Error getting stock info: %v", err)
 		stockInfo = map[string]interface{}{"error": "Could not retrieve updated stock info"}
 	}
-	
+
 	response := map[string]interface{}{
 		"message":    "Crisis event forced successfully",
 		"success":    true,
@@ -613,7 +610,7 @@ func (h *AdminHandler) ForceCrisisEvent(w http.ResponseWriter, r *http.Request) 
 		"stock_info": stockInfo,
 		"timestamp":  time.Now().String(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -621,46 +618,46 @@ func (h *AdminHandler) ForceCrisisEvent(w http.ResponseWriter, r *http.Request) 
 // ForceBankruptcy forces a stock into bankruptcy for testing (admin only)
 func (h *AdminHandler) ForceBankruptcy(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	var req struct {
 		StockID int `json:"stock_id"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	
+
 	if req.StockID <= 0 {
 		http.Error(w, "Invalid stock ID", http.StatusBadRequest)
 		return
 	}
-	
+
 	log.Printf("🧪 Admin forcing bankruptcy for stock ID: %d", req.StockID)
-	
+
 	err := h.marketService.ForceBankruptcy(req.StockID)
 	if err != nil {
 		log.Printf("Error forcing bankruptcy: %v", err)
 		http.Error(w, fmt.Sprintf("Error forcing bankruptcy: %v", err), http.StatusInternalServerError)
 		return
 	}
-	
+
 	stockInfo, err := h.marketService.GetSimulatorStockInfo(req.StockID)
 	if err != nil {
 		log.Printf("Error getting stock info: %v", err)
 		stockInfo = map[string]interface{}{"error": "Could not retrieve updated stock info"}
 	}
-	
+
 	response := map[string]interface{}{
 		"message":    "Bankruptcy forced successfully",
 		"success":    true,
@@ -668,7 +665,7 @@ func (h *AdminHandler) ForceBankruptcy(w http.ResponseWriter, r *http.Request) {
 		"stock_info": stockInfo,
 		"timestamp":  time.Now().String(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -676,46 +673,46 @@ func (h *AdminHandler) ForceBankruptcy(w http.ResponseWriter, r *http.Request) {
 // ForceRecovery forces a stock recovery for testing (admin only)
 func (h *AdminHandler) ForceRecovery(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	var req struct {
 		StockID int `json:"stock_id"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	
+
 	if req.StockID <= 0 {
 		http.Error(w, "Invalid stock ID", http.StatusBadRequest)
 		return
 	}
-	
+
 	log.Printf("🧪 Admin forcing recovery for stock ID: %d", req.StockID)
-	
+
 	err := h.marketService.ForceRecovery(req.StockID)
 	if err != nil {
 		log.Printf("Error forcing recovery: %v", err)
 		http.Error(w, fmt.Sprintf("Error forcing recovery: %v", err), http.StatusInternalServerError)
 		return
 	}
-	
+
 	stockInfo, err := h.marketService.GetSimulatorStockInfo(req.StockID)
 	if err != nil {
 		log.Printf("Error getting stock info: %v", err)
 		stockInfo = map[string]interface{}{"error": "Could not retrieve updated stock info"}
 	}
-	
+
 	response := map[string]interface{}{
 		"message":    "Recovery forced successfully",
 		"success":    true,
@@ -723,7 +720,7 @@ func (h *AdminHandler) ForceRecovery(w http.ResponseWriter, r *http.Request) {
 		"stock_info": stockInfo,
 		"timestamp":  time.Now().String(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -731,21 +728,21 @@ func (h *AdminHandler) ForceRecovery(w http.ResponseWriter, r *http.Request) {
 // GetSimulatorStatus returns the current status of all stocks in the simulator (admin only)
 func (h *AdminHandler) GetSimulatorStatus(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "GET" {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	log.Println("🧪 Admin requesting simulator status")
-	
+
 	stocks := h.marketService.ListSimulatorStocks()
-	
+
 	response := map[string]interface{}{
 		"message":     "Simulator status retrieved successfully",
 		"success":     true,
@@ -753,7 +750,7 @@ func (h *AdminHandler) GetSimulatorStatus(w http.ResponseWriter, r *http.Request
 		"stock_count": len(stocks),
 		"timestamp":   time.Now().String(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -761,19 +758,19 @@ func (h *AdminHandler) GetSimulatorStatus(w http.ResponseWriter, r *http.Request
 // GetAllStocksDetailed returns all stocks with full details for admin management
 func (h *AdminHandler) GetAllStocksDetailed(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	stocks, err := h.stockRepo.GetAllStocks()
 	if err != nil {
 		log.Printf("Error getting stocks: %v", err)
 		http.Error(w, "Failed to get stocks", http.StatusInternalServerError)
 		return
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stocks)
 }
@@ -781,17 +778,17 @@ func (h *AdminHandler) GetAllStocksDetailed(w http.ResponseWriter, r *http.Reque
 // CreateStock creates a new stock
 func (h *AdminHandler) CreateStock(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	var req struct {
 		Symbol            string  `json:"symbol"`
 		Name              string  `json:"name"`
@@ -802,18 +799,18 @@ func (h *AdminHandler) CreateStock(w http.ResponseWriter, r *http.Request) {
 		VolatilityProfile string  `json:"volatility_profile"`
 		Description       string  `json:"description"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	
+
 	// Validate required fields
 	if req.Symbol == "" || req.Name == "" || req.InitialPrice <= 0 {
 		http.Error(w, "Missing required fields", http.StatusBadRequest)
 		return
 	}
-	
+
 	// Create the stock
 	stock, err := h.stockRepo.CreateStock(
 		req.Symbol, req.Name, req.Sector, req.SectorID,
@@ -824,10 +821,10 @@ func (h *AdminHandler) CreateStock(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to create stock", http.StatusInternalServerError)
 		return
 	}
-	
+
 	// Add to market simulator
 	h.marketService.AddStockToSimulator(stock)
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stock)
 }
@@ -835,31 +832,31 @@ func (h *AdminHandler) CreateStock(w http.ResponseWriter, r *http.Request) {
 // UpdateStockAdmin updates stock details
 func (h *AdminHandler) UpdateStockAdmin(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "PUT" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	// Extract stock ID from URL
 	pathParts := strings.Split(r.URL.Path, "/")
 	if len(pathParts) < 4 {
 		http.Error(w, "Invalid URL path", http.StatusBadRequest)
 		return
 	}
-	
+
 	stockIDStr := pathParts[len(pathParts)-1]
 	stockID, err := strconv.Atoi(stockIDStr)
 	if err != nil {
 		http.Error(w, "Invalid stock ID", http.StatusBadRequest)
 		return
 	}
-	
+
 	var req struct {
 		Name              string  `json:"name"`
 		Sector            string  `json:"sector"`
@@ -868,14 +865,14 @@ func (h *AdminHandler) UpdateStockAdmin(w http.ResponseWriter, r *http.Request) 
 		VolatilityProfile string  `json:"volatility_profile"`
 		Description       string  `json:"description"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	
+
 	log.Printf("🔬 Admin stock update - ID: %d, Request: %+v", stockID, req)
-	
+
 	// Get existing stock data to preserve values not being updated
 	existingStock, err := h.stockRepo.GetStockByID(stockID)
 	if err != nil {
@@ -883,18 +880,18 @@ func (h *AdminHandler) UpdateStockAdmin(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Stock not found", http.StatusNotFound)
 		return
 	}
-	
+
 	// Use existing values for fields that are empty/default in the request
 	name := req.Name
 	if name == "" {
 		name = existingStock.Name
 	}
-	
+
 	sector := req.Sector
 	if sector == "" {
 		sector = existingStock.Sector
 	}
-	
+
 	sectorID := req.SectorID
 	if sectorID <= 0 {
 		// Use existing sector_id, or default to 1 if existing is also invalid
@@ -905,18 +902,18 @@ func (h *AdminHandler) UpdateStockAdmin(w http.ResponseWriter, r *http.Request) 
 		}
 		log.Printf("🔧 Using preserved/default sector_id: %d", sectorID)
 	}
-	
+
 	volatilityProfile := req.VolatilityProfile
 	if volatilityProfile == "" {
 		volatilityProfile = "normal" // Default value
 	}
-	
+
 	description := req.Description
 	// Description can be empty, so we allow it
-	
-	log.Printf("🔬 Final update parameters: name=%s, sector=%s, sectorID=%d, volatility=%s", 
+
+	log.Printf("🔬 Final update parameters: name=%s, sector=%s, sectorID=%d, volatility=%s",
 		name, sector, sectorID, volatilityProfile)
-	
+
 	// Update stock details
 	err = h.stockRepo.UpdateStockDetails(stockID, name, sector, sectorID, volatilityProfile, description)
 	if err != nil {
@@ -924,15 +921,14 @@ func (h *AdminHandler) UpdateStockAdmin(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Failed to update stock", http.StatusInternalServerError)
 		return
 	}
-	
+
 	// Update price if provided
 	if req.CurrentPrice > 0 {
-		err = h.stockRepo.UpdateStockPrice(stockID, req.CurrentPrice)
-		if err != nil {
+		if err = h.marketService.UpdateStockPrice(stockID, req.CurrentPrice); err != nil {
 			log.Printf("Error updating stock price: %v", err)
 		}
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stock updated successfully"})
 }
@@ -940,31 +936,31 @@ func (h *AdminHandler) UpdateStockAdmin(w http.ResponseWriter, r *http.Request) 
 // DeleteStockAdmin soft deletes a stock
 func (h *AdminHandler) DeleteStockAdmin(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "DELETE" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	// Extract stock ID from URL
 	pathParts := strings.Split(r.URL.Path, "/")
 	if len(pathParts) < 4 {
 		http.Error(w, "Invalid URL path", http.StatusBadRequest)
 		return
 	}
-	
+
 	stockIDStr := pathParts[len(pathParts)-1]
 	stockID, err := strconv.Atoi(stockIDStr)
 	if err != nil {
 		http.Error(w, "Invalid stock ID", http.StatusBadRequest)
 		return
 	}
-	
+
 	// Force delisting
 	err = h.stockRepo.ForceDelisting(stockID, "Admin deletion")
 	if err != nil {
@@ -972,7 +968,7 @@ func (h *AdminHandler) DeleteStockAdmin(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Failed to delete stock", http.StatusInternalServerError)
 		return
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"message": "Stock deleted successfully"})
 }
@@ -980,17 +976,17 @@ func (h *AdminHandler) DeleteStockAdmin(w http.ResponseWriter, r *http.Request) 
 // LaunchIPO launches a new stock as an IPO
 func (h *AdminHandler) LaunchIPO(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	var req struct {
 		Symbol          string  `json:"symbol"`
 		Name            string  `json:"name"`
@@ -999,17 +995,17 @@ func (h *AdminHandler) LaunchIPO(w http.ResponseWriter, r *http.Request) {
 		IPOPrice        float64 `json:"ipo_price"`
 		SharesAvailable int     `json:"shares_available"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	
+
 	// Default shares if not provided
 	if req.SharesAvailable == 0 {
 		req.SharesAvailable = 1000000
 	}
-	
+
 	// Launch IPO
 	stock, err := h.stockRepo.LaunchIPO(
 		req.Symbol, req.Name, req.Sector, req.SectorID,
@@ -1020,13 +1016,13 @@ func (h *AdminHandler) LaunchIPO(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to launch IPO", http.StatusInternalServerError)
 		return
 	}
-	
+
 	// Add to market simulator
 	h.marketService.AddStockToSimulator(stock)
-	
+
 	// Create news event for IPO
 	h.marketService.GenerateIPONews(stock)
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(stock)
 }
@@ -1034,29 +1030,29 @@ func (h *AdminHandler) LaunchIPO(w http.ResponseWriter, r *http.Request) {
 // TriggerSectorEvent triggers a sector-wide market event
 func (h *AdminHandler) TriggerSectorEvent(w http.ResponseWriter, r *http.Request) {
 	setCORSHeaders(w, r)
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	var req struct {
 		SectorID         int     `json:"sector_id"`
 		EventType        string  `json:"event_type"` // "boom" or "crash"
 		ImpactPercentage float64 `json:"impact_percentage"`
 		DurationMinutes  int     `json:"duration_minutes"`
 	}
-	
+
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
-	
+
 	// Apply sector-wide impact
 	err := h.marketService.ApplySectorEvent(req.SectorID, req.EventType, req.ImpactPercentage, req.DurationMinutes)
 	if err != nil {
@@ -1064,7 +1060,7 @@ func (h *AdminHandler) TriggerSectorEvent(w http.ResponseWriter, r *http.Request
 		http.Error(w, "Failed to apply sector event", http.StatusInternalServerError)
 		return
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"message": "Sector event triggered successfully"})
 }

--- a/internal/handlers/test_handler.go
+++ b/internal/handlers/test_handler.go
@@ -14,14 +14,14 @@ import (
 
 // TestHandler handles test orchestration endpoints
 type TestHandler struct {
-	db             *sql.DB
-	marketService  *services.MarketService
-	userService    *services.UserService
-	stockRepo      models.StockRepository
-	portfolioRepo  models.PortfolioRepository
-	delistedRepo   models.DelistedStockRepository
-	lossRepo       models.PortfolioLossRepository
-	newsRepo       models.NewsRepository
+	db            *sql.DB
+	marketService *services.MarketService
+	userService   *services.UserService
+	stockRepo     models.StockRepository
+	portfolioRepo models.PortfolioRepository
+	delistedRepo  models.DelistedStockRepository
+	lossRepo      models.PortfolioLossRepository
+	newsRepo      models.NewsRepository
 }
 
 // NewTestHandler creates a new test handler
@@ -36,14 +36,14 @@ func NewTestHandler(
 	newsRepo models.NewsRepository,
 ) *TestHandler {
 	return &TestHandler{
-		db:             db,
-		marketService:  marketService,
-		userService:    userService,
-		stockRepo:      stockRepo,
-		portfolioRepo:  portfolioRepo,
-		delistedRepo:   delistedRepo,
-		lossRepo:       lossRepo,
-		newsRepo:       newsRepo,
+		db:            db,
+		marketService: marketService,
+		userService:   userService,
+		stockRepo:     stockRepo,
+		portfolioRepo: portfolioRepo,
+		delistedRepo:  delistedRepo,
+		lossRepo:      lossRepo,
+		newsRepo:      newsRepo,
 	}
 }
 
@@ -52,7 +52,7 @@ type TestResult struct {
 	TestName    string                 `json:"test_name"`
 	Status      string                 `json:"status"` // "running", "passed", "failed"
 	Message     string                 `json:"message"`
-	Duration    int                    `json:"duration"`    // Duration in milliseconds
+	Duration    int                    `json:"duration"` // Duration in milliseconds
 	StartedAt   time.Time              `json:"started_at"`
 	CompletedAt time.Time              `json:"completed_at"`
 	Details     map[string]interface{} `json:"details,omitempty"`
@@ -61,13 +61,13 @@ type TestResult struct {
 
 // TestSuite represents a collection of test results
 type TestSuite struct {
-	SuiteName   string       `json:"suite_name"`
-	StartTime   time.Time    `json:"start_time"`
-	EndTime     time.Time    `json:"end_time"`
-	TotalTests  int          `json:"total_tests"`
-	Passed      int          `json:"passed"`
-	Failed      int          `json:"failed"`
-	Tests       []TestResult `json:"tests"`
+	SuiteName  string       `json:"suite_name"`
+	StartTime  time.Time    `json:"start_time"`
+	EndTime    time.Time    `json:"end_time"`
+	TotalTests int          `json:"total_tests"`
+	Passed     int          `json:"passed"`
+	Failed     int          `json:"failed"`
+	Tests      []TestResult `json:"tests"`
 }
 
 // RunCrisisTests runs the crisis mechanics test suite (admin only)
@@ -85,7 +85,7 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get stocks: %w", err)
 		}
-		
+
 		var targetStock *models.Stock
 		for _, s := range stocks {
 			if s.CurrentPrice > 10 && s.Status == models.StockActive {
@@ -93,23 +93,23 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
-		
+
 		if targetStock == nil {
 			return nil, fmt.Errorf("no suitable stock found for crisis test")
 		}
-		
+
 		// Force crisis
 		err = h.marketService.ForceCrisisEvent(targetStock.ID)
 		if err != nil {
 			return nil, err
 		}
-		
+
 		// Wait for processing
 		time.Sleep(2 * time.Second)
-		
+
 		// Verify
 		updatedStock, _ := h.stockRepo.GetStockByID(targetStock.ID)
-		
+
 		return map[string]interface{}{
 			"stock_id":     targetStock.ID,
 			"stock_symbol": targetStock.Symbol,
@@ -125,7 +125,7 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 		stocks, _ := h.stockRepo.GetAllStocks()
 		var targetStock *models.Stock
 		var holderCount int
-		
+
 		for _, s := range stocks {
 			holders, _ := h.portfolioRepo.GetAllHoldersOfStock(s.ID)
 			if len(holders) > 0 && s.Status != models.StockDelisted {
@@ -134,37 +134,37 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
-		
+
 		if targetStock == nil {
 			return nil, fmt.Errorf("no stock with holders found")
 		}
-		
+
 		// Force bankruptcy
 		err := h.marketService.ForceBankruptcy(targetStock.ID)
 		if err != nil {
 			return nil, err
 		}
-		
+
 		// Wait for processing
 		time.Sleep(3 * time.Second)
-		
+
 		// Verify holdings removed
 		remainingHolders, _ := h.portfolioRepo.GetAllHoldersOfStock(targetStock.ID)
-		
+
 		// Check losses recorded
 		losses, _ := h.lossRepo.GetLossesByStock(targetStock.ID, 100)
-		
+
 		// Check delisted
 		delisted, _ := h.delistedRepo.GetDelistedStockByID(targetStock.ID)
-		
+
 		return map[string]interface{}{
-			"stock_id":           targetStock.ID,
-			"stock_symbol":       targetStock.Symbol,
-			"holders_before":     holderCount,
-			"holders_after":      len(remainingHolders),
-			"losses_recorded":    len(losses),
-			"delisted":           delisted != nil,
-			"delisting_reason":   delisted.Reason,
+			"stock_id":         targetStock.ID,
+			"stock_symbol":     targetStock.Symbol,
+			"holders_before":   holderCount,
+			"holders_after":    len(remainingHolders),
+			"losses_recorded":  len(losses),
+			"delisted":         delisted != nil,
+			"delisting_reason": delisted.Reason,
 		}, nil
 	})
 
@@ -173,14 +173,14 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 		// Find or create a crisis stock
 		stocks, _ := h.stockRepo.GetAllStocks()
 		var targetStock *models.Stock
-		
+
 		for _, s := range stocks {
 			if s.CurrentPrice <= 0.01 && s.Status == models.StockDistressed {
 				targetStock = s
 				break
 			}
 		}
-		
+
 		if targetStock == nil {
 			// Create one by forcing crisis
 			for _, s := range stocks {
@@ -192,32 +192,32 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		
+
 		if targetStock == nil {
 			return nil, fmt.Errorf("could not create crisis stock")
 		}
-		
+
 		priceBefore := targetStock.CurrentPrice
-		
+
 		// Force recovery
 		err := h.marketService.ForceRecovery(targetStock.ID)
 		if err != nil {
 			return nil, err
 		}
-		
+
 		// Wait for processing
 		time.Sleep(2 * time.Second)
-		
+
 		// Verify
 		updatedStock, _ := h.stockRepo.GetStockByID(targetStock.ID)
-		
+
 		return map[string]interface{}{
-			"stock_id":        targetStock.ID,
-			"stock_symbol":    targetStock.Symbol,
-			"price_before":    priceBefore,
-			"price_after":     updatedStock.CurrentPrice,
-			"price_increase":  fmt.Sprintf("%.0fx", updatedStock.CurrentPrice/priceBefore),
-			"status":          updatedStock.Status,
+			"stock_id":       targetStock.ID,
+			"stock_symbol":   targetStock.Symbol,
+			"price_before":   priceBefore,
+			"price_after":    updatedStock.CurrentPrice,
+			"price_increase": fmt.Sprintf("%.0fx", updatedStock.CurrentPrice/priceBefore),
+			"status":         updatedStock.Status,
 		}, nil
 	})
 
@@ -228,11 +228,11 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return nil, err
 		}
-		
+
 		crisisCount := 0
 		bankruptcyCount := 0
 		recoveryCount := 0
-		
+
 		for _, n := range news {
 			switch n.Type {
 			case models.NewsTypeCrisis:
@@ -243,12 +243,12 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 				recoveryCount++
 			}
 		}
-		
+
 		return map[string]interface{}{
-			"total_news":       len(news),
-			"crisis_news":      crisisCount,
-			"bankruptcy_news":  bankruptcyCount,
-			"recovery_news":    recoveryCount,
+			"total_news":      len(news),
+			"crisis_news":     crisisCount,
+			"bankruptcy_news": bankruptcyCount,
+			"recovery_news":   recoveryCount,
 		}, nil
 	})
 
@@ -256,7 +256,7 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 	h.runTest(&suite, "Sector Contagion Check", func() (map[string]interface{}, error) {
 		// This is harder to test automatically but we can check for patterns
 		stocks, _ := h.stockRepo.GetAllStocks()
-		
+
 		sectorStats := make(map[string]map[string]int)
 		for _, s := range stocks {
 			if _, exists := sectorStats[s.Sector]; !exists {
@@ -267,7 +267,7 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 					"delisted":   0,
 				}
 			}
-			
+
 			sectorStats[s.Sector]["total"]++
 			switch s.Status {
 			case models.StockActive:
@@ -278,7 +278,7 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 				sectorStats[s.Sector]["delisted"]++
 			}
 		}
-		
+
 		return map[string]interface{}{
 			"sector_breakdown": sectorStats,
 		}, nil
@@ -302,17 +302,17 @@ func (h *TestHandler) RunCrisisTests(w http.ResponseWriter, r *http.Request) {
 // Helper function to run individual tests
 func (h *TestHandler) runTest(suite *TestSuite, testName string, testFunc func() (map[string]interface{}, error)) {
 	startTime := time.Now()
-	
+
 	result := TestResult{
 		TestName: testName,
 		Status:   "running",
 	}
-	
+
 	details, err := testFunc()
-	
+
 	duration := time.Since(startTime)
 	result.Duration = int(duration.Milliseconds())
-	
+
 	if err != nil {
 		result.Status = "failed"
 		result.Error = err.Error()
@@ -322,9 +322,9 @@ func (h *TestHandler) runTest(suite *TestSuite, testName string, testFunc func()
 		result.Message = "Test completed successfully"
 		result.Details = details
 	}
-	
+
 	suite.Tests = append(suite.Tests, result)
-	
+
 	log.Printf("Test '%s': %s (duration: %d ms)", testName, result.Status, result.Duration)
 }
 
@@ -371,9 +371,9 @@ func (h *TestHandler) RunSSETests(w http.ResponseWriter, r *http.Request) {
 		}
 
 		return map[string]interface{}{
-			"total_stocks":      len(stocks),
-			"valid_prices":      validPrices,
-			"simulator_status":  "active",
+			"total_stocks":     len(stocks),
+			"valid_prices":     validPrices,
+			"simulator_status": "active",
 			"sample_prices": map[string]float64{
 				stocks[0].Symbol: stocks[0].CurrentPrice,
 			},
@@ -413,10 +413,10 @@ func (h *TestHandler) RunSSETests(w http.ResponseWriter, r *http.Request) {
 		// This test verifies that SSE endpoint should bypass rate limiting
 		// We can't test the actual bypass here, but we can document the expected behavior
 		return map[string]interface{}{
-			"sse_endpoint":         "/api/sse/stock-updates",
-			"rate_limit_bypass":    "expected",
-			"connection_type":      "persistent",
-			"update_frequency":     "2 seconds",
+			"sse_endpoint":           "/api/sse/stock-updates",
+			"rate_limit_bypass":      "expected",
+			"connection_type":        "persistent",
+			"update_frequency":       "2 seconds",
 			"max_reconnect_attempts": 10,
 		}, nil
 	})
@@ -472,42 +472,42 @@ func (h *TestHandler) GetTestStatus(w http.ResponseWriter, r *http.Request) {
 func (h *TestHandler) RunStockManagementTests(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	log.Printf("🧪 Starting stock management debugging tests...")
-	
+
 	results := []TestResult{}
-	
+
 	// Test 1: Database Schema Check
 	results = append(results, h.testDatabaseSchema())
-	
+
 	// Test 2: Sectors Table Check
 	results = append(results, h.testSectorsTable())
-	
+
 	// Test 3: Basic Stock Retrieval
 	results = append(results, h.testBasicStockRetrieval())
-	
+
 	// Test 4: Stock Creation
 	results = append(results, h.testStockCreation())
-	
+
 	// Test 5: Stock Update (the failing operation)
 	results = append(results, h.testStockUpdate())
-	
+
 	// Test 6: IPO Launch
 	results = append(results, h.testIPOLaunch())
-	
+
 	// Test 7: Stock Deletion
 	results = append(results, h.testStockDeletion())
-	
+
 	// Summary
 	passed := 0
 	failed := 0
@@ -518,17 +518,17 @@ func (h *TestHandler) RunStockManagementTests(w http.ResponseWriter, r *http.Req
 			failed++
 		}
 	}
-	
+
 	response := map[string]interface{}{
 		"summary": map[string]int{
 			"total":  len(results),
 			"passed": passed,
 			"failed": failed,
 		},
-		"tests": results,
+		"tests":     results,
 		"timestamp": time.Now().Format(time.RFC3339),
 	}
-	
+
 	log.Printf("🧪 Stock management tests completed: %d passed, %d failed", passed, failed)
 	json.NewEncoder(w).Encode(response)
 }
@@ -552,7 +552,7 @@ func (h *TestHandler) testDatabaseSchema() TestResult {
 // testBasicStockRetrieval tests getting all stocks
 func (h *TestHandler) testBasicStockRetrieval() TestResult {
 	start := time.Now()
-	
+
 	stocks, err := h.stockRepo.GetAllStocks()
 	if err != nil {
 		return TestResult{
@@ -567,7 +567,7 @@ func (h *TestHandler) testBasicStockRetrieval() TestResult {
 			},
 		}
 	}
-	
+
 	return TestResult{
 		TestName:    "Basic Stock Retrieval",
 		Status:      "passed",
@@ -595,13 +595,13 @@ func (h *TestHandler) testBasicStockRetrieval() TestResult {
 // testStockCreation tests creating a new stock
 func (h *TestHandler) testStockCreation() TestResult {
 	start := time.Now()
-	
+
 	testSymbol := fmt.Sprintf("TEST%d", time.Now().Unix()%1000)
-	
+
 	stock, err := h.stockRepo.CreateStock(
 		testSymbol, "Test Company", "Technology", 1, 10.00, "mid", "normal", "Test description",
 	)
-	
+
 	if err != nil {
 		return TestResult{
 			TestName:    "Stock Creation",
@@ -611,12 +611,12 @@ func (h *TestHandler) testStockCreation() TestResult {
 			StartedAt:   start,
 			CompletedAt: time.Now(),
 			Details: map[string]interface{}{
-				"error":        err.Error(),
-				"test_symbol":  testSymbol,
+				"error":       err.Error(),
+				"test_symbol": testSymbol,
 			},
 		}
 	}
-	
+
 	return TestResult{
 		TestName:    "Stock Creation",
 		Status:      "passed",
@@ -638,7 +638,7 @@ func (h *TestHandler) testStockCreation() TestResult {
 // testStockUpdate tests updating stock details (the failing operation)
 func (h *TestHandler) testStockUpdate() TestResult {
 	start := time.Now()
-	
+
 	// Get first stock to test update
 	stocks, err := h.stockRepo.GetAllStocks()
 	if err != nil || len(stocks) == 0 {
@@ -651,14 +651,14 @@ func (h *TestHandler) testStockUpdate() TestResult {
 			CompletedAt: time.Now(),
 		}
 	}
-	
+
 	testStock := stocks[0]
 	originalName := testStock.Name
 	newName := "UPDATED " + originalName
-	
+
 	// Try updating with UpdateStockDetails method
 	err = h.stockRepo.UpdateStockDetails(testStock.ID, newName, testStock.Sector, 1, "normal", "Updated description")
-	
+
 	if err != nil {
 		return TestResult{
 			TestName:    "Stock Update",
@@ -668,18 +668,18 @@ func (h *TestHandler) testStockUpdate() TestResult {
 			StartedAt:   start,
 			CompletedAt: time.Now(),
 			Details: map[string]interface{}{
-				"error":        err.Error(),
-				"stock_id":     testStock.ID,
+				"error":         err.Error(),
+				"stock_id":      testStock.ID,
 				"original_name": originalName,
-				"new_name":     newName,
+				"new_name":      newName,
 				"update_method": "UpdateStockDetails",
 			},
 		}
 	}
-	
+
 	// Revert the change
 	h.stockRepo.UpdateStockDetails(testStock.ID, originalName, testStock.Sector, 1, "normal", "")
-	
+
 	return TestResult{
 		TestName:    "Stock Update",
 		Status:      "passed",
@@ -698,13 +698,13 @@ func (h *TestHandler) testStockUpdate() TestResult {
 // testIPOLaunch tests launching an IPO
 func (h *TestHandler) testIPOLaunch() TestResult {
 	start := time.Now()
-	
+
 	ipoSymbol := fmt.Sprintf("IPO%d", time.Now().Unix()%1000)
-	
+
 	stock, err := h.stockRepo.LaunchIPO(
 		ipoSymbol, "IPO Test Company", "Technology", 1, 1.50, 500000,
 	)
-	
+
 	if err != nil {
 		return TestResult{
 			TestName:    "IPO Launch",
@@ -719,7 +719,7 @@ func (h *TestHandler) testIPOLaunch() TestResult {
 			},
 		}
 	}
-	
+
 	return TestResult{
 		TestName:    "IPO Launch",
 		Status:      "passed",
@@ -741,13 +741,13 @@ func (h *TestHandler) testIPOLaunch() TestResult {
 // testStockDeletion tests soft-deleting a stock
 func (h *TestHandler) testStockDeletion() TestResult {
 	start := time.Now()
-	
+
 	// Create a test stock to delete
 	testSymbol := fmt.Sprintf("DEL%d", time.Now().Unix()%1000)
 	stock, err := h.stockRepo.CreateStock(
 		testSymbol, "Delete Test Company", "Technology", 1, 5.00, "small", "normal", "Test delete",
 	)
-	
+
 	if err != nil {
 		return TestResult{
 			TestName:    "Stock Deletion",
@@ -758,7 +758,7 @@ func (h *TestHandler) testStockDeletion() TestResult {
 			CompletedAt: time.Now(),
 		}
 	}
-	
+
 	// Now try to delete it
 	err = h.stockRepo.ForceDelisting(stock.ID, "Test deletion")
 	if err != nil {
@@ -775,7 +775,7 @@ func (h *TestHandler) testStockDeletion() TestResult {
 			},
 		}
 	}
-	
+
 	return TestResult{
 		TestName:    "Stock Deletion",
 		Status:      "passed",
@@ -785,7 +785,7 @@ func (h *TestHandler) testStockDeletion() TestResult {
 		CompletedAt: time.Now(),
 		Details: map[string]interface{}{
 			"deleted_stock_id": stock.ID,
-			"symbol": testSymbol,
+			"symbol":           testSymbol,
 		},
 	}
 }
@@ -794,19 +794,19 @@ func (h *TestHandler) testStockDeletion() TestResult {
 func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	log.Printf("🧪 Testing admin stock update endpoint...")
-	
+
 	// Get first stock to test with
 	stocks, err := h.stockRepo.GetAllStocks()
 	if err != nil || len(stocks) == 0 {
@@ -818,26 +818,26 @@ func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(result)
 		return
 	}
-	
+
 	testStock := stocks[0]
 	originalName := testStock.Name
 	testName := "ADMIN TEST " + originalName
-	
+
 	// Test the exact same format that the frontend sends
 	testData := map[string]interface{}{
 		"name":               testName,
 		"sector":             testStock.Sector,
-		"sector_id":          1, // Use a known good sector ID
+		"sector_id":          1,                            // Use a known good sector ID
 		"current_price":      testStock.CurrentPrice + 1.0, // Increment by $1
 		"volatility_profile": "normal",
 		"description":        "Admin panel test update",
 	}
-	
+
 	log.Printf("🔬 Testing with data: %+v", testData)
-	
+
 	// Convert to JSON to test the exact same data format that the frontend sends
 	testDataJSON, _ := json.Marshal(testData)
-	
+
 	// Simulate the admin update process directly
 	var req struct {
 		Name              string  `json:"name"`
@@ -847,7 +847,7 @@ func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Reques
 		VolatilityProfile string  `json:"volatility_profile"`
 		Description       string  `json:"description"`
 	}
-	
+
 	err = json.Unmarshal(testDataJSON, &req)
 	if err != nil {
 		result := map[string]interface{}{
@@ -858,9 +858,9 @@ func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Reques
 		json.NewEncoder(w).Encode(result)
 		return
 	}
-	
+
 	log.Printf("🔬 Parsed request data: %+v", req)
-	
+
 	// Test UpdateStockDetails
 	err = h.stockRepo.UpdateStockDetails(testStock.ID, req.Name, req.Sector, req.SectorID, req.VolatilityProfile, req.Description)
 	updateDetailsError := ""
@@ -870,11 +870,11 @@ func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Reques
 	} else {
 		log.Printf("✅ UpdateStockDetails succeeded")
 	}
-	
+
 	// Test UpdateStockPrice
 	priceUpdateError := ""
 	if req.CurrentPrice > 0 {
-		err = h.stockRepo.UpdateStockPrice(testStock.ID, req.CurrentPrice)
+		err = h.marketService.UpdateStockPrice(testStock.ID, req.CurrentPrice)
 		if err != nil {
 			priceUpdateError = err.Error()
 			log.Printf("❌ UpdateStockPrice failed: %v", err)
@@ -882,38 +882,38 @@ func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Reques
 			log.Printf("✅ UpdateStockPrice succeeded")
 		}
 	}
-	
+
 	// Get updated stock to verify changes
 	updatedStock, err := h.stockRepo.GetStockByID(testStock.ID)
 	verifyError := ""
 	if err != nil {
 		verifyError = err.Error()
 	}
-	
+
 	// Revert changes
 	h.stockRepo.UpdateStockDetails(testStock.ID, originalName, testStock.Sector, 1, "normal", "")
-	h.stockRepo.UpdateStockPrice(testStock.ID, testStock.CurrentPrice)
-	
+	h.marketService.UpdateStockPrice(testStock.ID, testStock.CurrentPrice)
+
 	result := map[string]interface{}{
-		"status":             "completed",
-		"message":            "Admin stock update test completed",
-		"test_stock_id":      testStock.ID,
-		"original_name":      originalName,
-		"test_name":          testName,
-		"original_price":     testStock.CurrentPrice,
-		"test_price":         req.CurrentPrice,
+		"status":               "completed",
+		"message":              "Admin stock update test completed",
+		"test_stock_id":        testStock.ID,
+		"original_name":        originalName,
+		"test_name":            testName,
+		"original_price":       testStock.CurrentPrice,
+		"test_price":           req.CurrentPrice,
 		"update_details_error": updateDetailsError,
 		"price_update_error":   priceUpdateError,
 		"verify_error":         verifyError,
 		"updated_stock":        updatedStock,
 		"request_data":         req,
 	}
-	
+
 	if updateDetailsError != "" || priceUpdateError != "" || verifyError != "" {
 		result["status"] = "failed"
 		result["message"] = "Admin stock update test had errors"
 	}
-	
+
 	json.NewEncoder(w).Encode(result)
 }
 
@@ -921,29 +921,29 @@ func (h *TestHandler) TestStockAdminUpdate(w http.ResponseWriter, r *http.Reques
 func (h *TestHandler) CreateMissingSectors(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	
+
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	
+
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	
+
 	log.Printf("🔧 Creating missing sectors to fix foreign key constraints...")
-	
+
 	// Check if database connection is available
 	if h.db == nil {
 		result := map[string]interface{}{
-			"status": "error",
+			"status":  "error",
 			"message": "Database connection not available",
 		}
 		json.NewEncoder(w).Encode(result)
 		return
 	}
-	
+
 	// Define the sectors to create
 	sectors := []struct {
 		ID   int
@@ -960,10 +960,10 @@ func (h *TestHandler) CreateMissingSectors(w http.ResponseWriter, r *http.Reques
 		{9, "Materials"},
 		{10, "Communications"},
 	}
-	
+
 	created := 0
 	errors := []string{}
-	
+
 	// Try to create each sector
 	for _, sector := range sectors {
 		query := `INSERT INTO sectors (id, name) VALUES (?, ?) ON DUPLICATE KEY UPDATE name = VALUES(name)`
@@ -976,12 +976,12 @@ func (h *TestHandler) CreateMissingSectors(w http.ResponseWriter, r *http.Reques
 			log.Printf("✅ Created/updated sector %d: %s", sector.ID, sector.Name)
 		}
 	}
-	
+
 	// Verify sectors were created by querying them back
 	verifyQuery := `SELECT id, name FROM sectors ORDER BY id`
 	rows, err := h.db.Query(verifyQuery)
 	var existingSectors []map[string]interface{}
-	
+
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -995,7 +995,7 @@ func (h *TestHandler) CreateMissingSectors(w http.ResponseWriter, r *http.Reques
 			}
 		}
 	}
-	
+
 	result := map[string]interface{}{
 		"status":           "completed",
 		"message":          fmt.Sprintf("Created/updated %d sectors", created),
@@ -1008,19 +1008,19 @@ func (h *TestHandler) CreateMissingSectors(w http.ResponseWriter, r *http.Reques
 			"Stock operations should now work without foreign key errors",
 		},
 	}
-	
+
 	if len(errors) > 0 {
 		result["status"] = "partial_success"
 		result["message"] = fmt.Sprintf("Created %d sectors with %d errors", created, len(errors))
 	}
-	
+
 	json.NewEncoder(w).Encode(result)
 }
 
 // testSectorsTable checks what sectors exist and creates missing ones
 func (h *TestHandler) testSectorsTable() TestResult {
 	start := time.Now()
-	
+
 	// Check if we have access to the sectors repository through a stock repository method
 	// First, let's check what sectors exist by examining existing stocks
 	stocks, err := h.stockRepo.GetAllStocks()
@@ -1034,7 +1034,7 @@ func (h *TestHandler) testSectorsTable() TestResult {
 			CompletedAt: time.Now(),
 		}
 	}
-	
+
 	// Collect unique sector information from existing stocks
 	sectorMap := make(map[int]string)
 	for _, stock := range stocks {
@@ -1042,25 +1042,25 @@ func (h *TestHandler) testSectorsTable() TestResult {
 			sectorMap[*stock.SectorID] = stock.Sector
 		}
 	}
-	
+
 	// Check if sector_id = 1 exists (the one our tests are trying to use)
 	_, hasSectorOne := sectorMap[1]
-	
+
 	details := map[string]interface{}{
-		"existing_sectors": sectorMap,
+		"existing_sectors":   sectorMap,
 		"sector_id_1_exists": hasSectorOne,
-		"stocks_examined": len(stocks),
-		"note": "Foreign key constraint requires valid sector_id references",
+		"stocks_examined":    len(stocks),
+		"note":               "Foreign key constraint requires valid sector_id references",
 	}
-	
+
 	status := "passed"
 	message := fmt.Sprintf("Found %d sectors from existing stocks", len(sectorMap))
-	
+
 	if !hasSectorOne {
 		status = "failed"
 		message = "Sector ID 1 (Technology) not found - this is causing the foreign key constraint failures"
 		details["required_action"] = "Need to create sector with ID 1 or use existing sector IDs"
-		
+
 		if len(sectorMap) > 0 {
 			// Suggest using the first available sector ID
 			for id, name := range sectorMap {
@@ -1070,7 +1070,7 @@ func (h *TestHandler) testSectorsTable() TestResult {
 			}
 		}
 	}
-	
+
 	return TestResult{
 		TestName:    "Sectors Table Check",
 		Status:      status,

--- a/internal/services/market_service.go
+++ b/internal/services/market_service.go
@@ -13,15 +13,15 @@ import (
 
 // MarketService handles stock market operations
 type MarketService struct {
-	stockRepo           models.StockRepository
-	userRepo            models.UserRepository
-	portfolioRepo       models.PortfolioRepository
-	transactionRepo     models.TransactionRepository
-	sectorRepo          models.SectorRepository
-	delistedStockRepo   models.DelistedStockRepository
-	portfolioLossRepo   models.PortfolioLossRepository
-	newsService         *NewsService
-	simulator           *market.MarketSimulator
+	stockRepo         models.StockRepository
+	userRepo          models.UserRepository
+	portfolioRepo     models.PortfolioRepository
+	transactionRepo   models.TransactionRepository
+	sectorRepo        models.SectorRepository
+	delistedStockRepo models.DelistedStockRepository
+	portfolioLossRepo models.PortfolioLossRepository
+	newsService       *NewsService
+	simulator         *market.MarketSimulator
 }
 
 // NewMarketService creates a new market service
@@ -38,28 +38,28 @@ func NewMarketService(
 	// Create a market simulator with faster updates and higher volatility for more dynamic price movements
 	// 2-second updates and 5% volatility
 	simulator := market.NewMarketSimulator(2*time.Second, 0.05)
-	
+
 	// Create the service first
 	service := &MarketService{
-		stockRepo:           stockRepo,
-		userRepo:            userRepo,
-		portfolioRepo:       portfolioRepo,
-		transactionRepo:     transactionRepo,
-		sectorRepo:          sectorRepo,
-		delistedStockRepo:   delistedStockRepo,
-		portfolioLossRepo:   portfolioLossRepo,
-		newsService:         newsService,
-		simulator:           simulator,
+		stockRepo:         stockRepo,
+		userRepo:          userRepo,
+		portfolioRepo:     portfolioRepo,
+		transactionRepo:   transactionRepo,
+		sectorRepo:        sectorRepo,
+		delistedStockRepo: delistedStockRepo,
+		portfolioLossRepo: portfolioLossRepo,
+		newsService:       newsService,
+		simulator:         simulator,
 	}
-	
+
 	// Connect the news service to the simulator for automated news generation
 	if newsService != nil {
 		simulator.SetNewsService(newsService)
 	}
-	
+
 	// Connect the bankruptcy handler (the service itself implements the interface)
 	simulator.SetBankruptcyHandler(service)
-	
+
 	return service
 }
 
@@ -70,37 +70,37 @@ func (s *MarketService) InitializeSimulator() error {
 	if err != nil {
 		log.Printf("Warning: Failed to load sectors from database: %v", err)
 		log.Println("Using mock data for market simulation (development mode)")
-		
+
 		// Use mock sectors for development
 		sectors = s.createMockSectors()
 	}
-	
+
 	// Add sectors to the simulator
 	for _, sector := range sectors {
 		s.simulator.AddSector(sector.ID, sector.Name, sector.VolatilityModifier)
 	}
-	
+
 	// Try to load stocks from the database
 	stocks, err := s.stockRepo.LoadStocksForSimulation()
 	if err != nil {
 		log.Printf("Warning: Failed to load stocks from database: %v", err)
 		log.Println("Using mock data for market simulation (development mode)")
-		
+
 		// Use mock stocks for development
 		stocks = s.createMockStocks()
 	}
-	
+
 	// Add stocks to the simulator
 	for id, stock := range stocks {
 		s.simulator.AddStock(id, stock.Symbol, stock.Name, stock.Sector, stock.SectorID, stock.Price)
 	}
-	
+
 	// Start the simulator
 	s.simulator.Start()
-	
+
 	// Start a goroutine to update stock prices in the database (if available)
 	go s.updateStockPrices()
-	
+
 	log.Printf("Market simulator initialized with %d sectors and %d stocks", len(sectors), len(stocks))
 	return nil
 }
@@ -153,25 +153,25 @@ func (s *MarketService) createMockStocks() map[int]struct {
 // updateStockPrices handles updates from the simulator
 func (s *MarketService) updateStockPrices() {
 	updateChan := s.simulator.GetUpdateChannel()
-	
+
 	log.Printf("📡 MarketService: Starting to listen for stock updates from simulator")
 	updatesProcessed := 0
 	lastLogTime := time.Now()
-	
+
 	for update := range updateChan {
 		updatesProcessed++
-		
+
 		// Log first few updates to verify flow
 		if updatesProcessed <= 5 {
 			log.Printf("📈 MarketService: Received update #%d - %s: $%.2f", updatesProcessed, update.Symbol, update.Price)
 		}
-		
+
 		// Validate price before updating database
 		if math.IsInf(update.Price, 0) || math.IsNaN(update.Price) || update.Price <= 0 {
 			log.Printf("⚠️ MarketService: Skipping database update for stock %s: invalid price %f", update.Symbol, update.Price)
 			continue
 		}
-		
+
 		// Ensure price is within reasonable bounds
 		price := update.Price
 		if price < 0.01 {
@@ -179,13 +179,13 @@ func (s *MarketService) updateStockPrices() {
 		} else if price > 1000000 {
 			price = 1000000
 		}
-		
+
 		// Update the stock price in the database
 		if err := s.stockRepo.UpdateStockPrice(update.StockID, price); err != nil {
 			log.Printf("❌ MarketService: Error updating stock price for %s: %v", update.Symbol, err)
 			continue
 		}
-		
+
 		// Log progress every 60 seconds
 		if time.Since(lastLogTime) >= 60*time.Second {
 			log.Printf("📊 MarketService: Processed %d stock updates in last 60s", updatesProcessed)
@@ -193,7 +193,7 @@ func (s *MarketService) updateStockPrices() {
 			lastLogTime = time.Now()
 		}
 	}
-	
+
 	log.Printf("🛑 MarketService: Stock update listener stopped")
 }
 
@@ -214,19 +214,19 @@ func (s *MarketService) GetUserPortfolio(userID int) (*models.PortfolioSummary, 
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Get the user's cash balance
 	user, err := s.userRepo.GetUserByID(userID)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Calculate total stock value
 	var stockValue float64
 	for _, item := range items {
 		stockValue += float64(item.Quantity) * item.Stock.CurrentPrice
 	}
-	
+
 	// Create the portfolio summary
 	summary := &models.PortfolioSummary{
 		CashBalance:    user.CashBalance,
@@ -234,7 +234,7 @@ func (s *MarketService) GetUserPortfolio(userID int) (*models.PortfolioSummary, 
 		TotalValue:     user.CashBalance + stockValue,
 		PortfolioItems: items,
 	}
-	
+
 	return summary, nil
 }
 
@@ -244,51 +244,51 @@ func (s *MarketService) BuyStock(userID, stockID, quantity int) error {
 	if quantity <= 0 {
 		return errors.New("quantity must be greater than zero")
 	}
-	
+
 	// Get the stock
 	stock, err := s.stockRepo.GetStockByID(stockID)
 	if err != nil {
 		return err
 	}
-	
+
 	// Get the user
 	user, err := s.userRepo.GetUserByID(userID)
 	if err != nil {
 		return err
 	}
-	
+
 	// Calculate total cost
 	totalCost := stock.CurrentPrice * float64(quantity)
-	
+
 	// Check if user has enough cash
 	if user.CashBalance < totalCost {
 		return errors.New("insufficient funds")
 	}
-	
+
 	// Begin transaction (in a real app, you'd use a database transaction here)
-	
+
 	// Update user's cash balance
 	newBalance := user.CashBalance - totalCost
 	if err := s.userRepo.UpdateUserBalance(userID, newBalance); err != nil {
 		return err
 	}
-	
+
 	// Update user's portfolio
 	if err := s.portfolioRepo.AddStockToPortfolio(userID, stockID, quantity); err != nil {
 		// In a real app, you'd roll back the balance change on error
 		return err
 	}
-	
+
 	// Record the transaction
 	_, err = s.transactionRepo.CreateTransaction(userID, stockID, quantity, stock.CurrentPrice, models.Buy)
 	if err != nil {
 		// In a real app, you'd roll back the previous changes on error
 		return err
 	}
-	
+
 	// Update market simulation
 	s.simulator.ProcessTransaction(stockID, quantity, true)
-	
+
 	return nil
 }
 
@@ -298,58 +298,58 @@ func (s *MarketService) SellStock(userID, stockID, quantity int) error {
 	if quantity <= 0 {
 		return errors.New("quantity must be greater than zero")
 	}
-	
+
 	// Get the stock
 	stock, err := s.stockRepo.GetStockByID(stockID)
 	if err != nil {
 		return err
 	}
-	
+
 	// Get the user's holding for this stock
 	holding, err := s.portfolioRepo.GetUserStockHolding(userID, stockID)
 	if err != nil {
 		return err
 	}
-	
+
 	// Check if user owns the stock and has enough shares
 	if holding == nil || holding.Quantity < quantity {
 		return errors.New("insufficient shares")
 	}
-	
+
 	// Get the user
 	user, err := s.userRepo.GetUserByID(userID)
 	if err != nil {
 		return err
 	}
-	
+
 	// Calculate total proceeds
 	totalProceeds := stock.CurrentPrice * float64(quantity)
-	
+
 	// Begin transaction (in a real app, you'd use a database transaction here)
-	
+
 	// Update user's cash balance
 	newBalance := user.CashBalance + totalProceeds
 	if err := s.userRepo.UpdateUserBalance(userID, newBalance); err != nil {
 		return err
 	}
-	
+
 	// Update user's portfolio
 	newQuantity := holding.Quantity - quantity
 	if err := s.portfolioRepo.UpdateStockQuantity(holding.ID, newQuantity); err != nil {
 		// In a real app, you'd roll back the balance change on error
 		return err
 	}
-	
+
 	// Record the transaction
 	_, err = s.transactionRepo.CreateTransaction(userID, stockID, quantity, stock.CurrentPrice, models.Sell)
 	if err != nil {
 		// In a real app, you'd roll back the previous changes on error
 		return err
 	}
-	
+
 	// Update market simulation
 	s.simulator.ProcessTransaction(stockID, quantity, false)
-	
+
 	return nil
 }
 
@@ -387,12 +387,12 @@ func (s *MarketService) ReloadSimulatorPrices() error {
 	if err != nil {
 		return err
 	}
-	
+
 	// Update each stock's price in the simulator
 	for id, stock := range stocks {
 		s.simulator.ReloadStock(id, stock.Price)
 	}
-	
+
 	return nil
 }
 
@@ -404,22 +404,22 @@ func (s *MarketService) AtomicResetStockPrices() error {
 		// Always resume the simulator, even if there was an error
 		s.simulator.Resume()
 	}()
-	
+
 	// Small delay to ensure pause takes effect
 	time.Sleep(100 * time.Millisecond)
-	
+
 	// Step 2: Reset prices in database
 	err := s.stockRepo.ResetAllStockPrices()
 	if err != nil {
 		return fmt.Errorf("failed to reset stock prices in database: %w", err)
 	}
-	
+
 	// Step 3: Reload simulator with new prices from database
 	err = s.ReloadSimulatorPrices()
 	if err != nil {
 		return fmt.Errorf("failed to reload simulator prices: %w", err)
 	}
-	
+
 	return nil
 }
 
@@ -446,15 +446,15 @@ func (s *MarketService) GetSimulatorStockInfo(stockID int) (map[string]interface
 	if !exists {
 		return nil, fmt.Errorf("stock with ID %d not found in simulator", stockID)
 	}
-	
+
 	return map[string]interface{}{
-		"id":         stock.ID,
-		"symbol":     stock.Symbol,
-		"name":       stock.Name,
-		"sector":     stock.Sector,
-		"sector_id":  stock.SectorID,
-		"base_price": stock.BasePrice,
-		"trend":      stock.Trend,
+		"id":            stock.ID,
+		"symbol":        stock.Symbol,
+		"name":          stock.Name,
+		"sector":        stock.Sector,
+		"sector_id":     stock.SectorID,
+		"base_price":    stock.BasePrice,
+		"trend":         stock.Trend,
 		"trend_counter": stock.TrendCounter,
 	}, nil
 }
@@ -463,20 +463,20 @@ func (s *MarketService) GetSimulatorStockInfo(stockID int) (map[string]interface
 func (s *MarketService) ListSimulatorStocks() map[int]map[string]interface{} {
 	stocks := s.simulator.ListAllStocks()
 	result := make(map[int]map[string]interface{})
-	
+
 	for id, stock := range stocks {
 		result[id] = map[string]interface{}{
-			"id":         stock.ID,
-			"symbol":     stock.Symbol,
-			"name":       stock.Name,
-			"sector":     stock.Sector,
-			"sector_id":  stock.SectorID,
-			"base_price": stock.BasePrice,
-			"trend":      stock.Trend,
+			"id":            stock.ID,
+			"symbol":        stock.Symbol,
+			"name":          stock.Name,
+			"sector":        stock.Sector,
+			"sector_id":     stock.SectorID,
+			"base_price":    stock.BasePrice,
+			"trend":         stock.Trend,
 			"trend_counter": stock.TrendCounter,
 		}
 	}
-	
+
 	return result
 }
 
@@ -487,17 +487,17 @@ func (s *MarketService) ProcessStockBankruptcy(stockID int) error {
 	if err != nil {
 		return fmt.Errorf("failed to get stock info: %w", err)
 	}
-	
+
 	log.Printf("💀 Processing bankruptcy for %s (%s)", stock.Symbol, stock.Name)
-	
+
 	// Step 1: Get all users who own this stock
 	holders, err := s.portfolioRepo.GetAllHoldersOfStock(stockID)
 	if err != nil {
 		return fmt.Errorf("failed to get stock holders: %w", err)
 	}
-	
+
 	log.Printf("Found %d users holding %s stock", len(holders), stock.Symbol)
-	
+
 	// Step 2: Record portfolio losses for all holders
 	for _, holding := range holders {
 		lossAmount := float64(holding.Quantity) * stock.CurrentPrice
@@ -516,7 +516,7 @@ func (s *MarketService) ProcessStockBankruptcy(stockID int) error {
 			log.Printf("💸 Recorded $%.2f loss for user %d from %s bankruptcy", lossAmount, holding.UserID, stock.Symbol)
 		}
 	}
-	
+
 	// Step 3: Record the delisted stock
 	err = s.delistedStockRepo.CreateDelistedStock(
 		stockID,
@@ -529,19 +529,19 @@ func (s *MarketService) ProcessStockBankruptcy(stockID int) error {
 	if err != nil {
 		return fmt.Errorf("failed to record delisted stock: %w", err)
 	}
-	
+
 	// Step 4: Remove stock from all portfolios
 	err = s.portfolioRepo.RemoveStockFromAllPortfolios(stockID)
 	if err != nil {
 		return fmt.Errorf("failed to remove stock from portfolios: %w", err)
 	}
-	
+
 	// Step 5: Mark stock as delisted in database
 	err = s.stockRepo.DelistStock(stockID)
 	if err != nil {
 		return fmt.Errorf("failed to delist stock: %w", err)
 	}
-	
+
 	log.Printf("✅ Bankruptcy processing completed for %s", stock.Symbol)
 	return nil
 }
@@ -558,9 +558,9 @@ func (s *MarketService) AddStockToSimulator(stock *models.Stock) {
 func (s *MarketService) GenerateIPONews(stock *models.Stock) {
 	if s.newsService != nil && stock != nil {
 		// Create IPO announcement news
-		newsContent := fmt.Sprintf("%s (%s) launches IPO at $%.2f per share. The %s sector welcomes its newest member!", 
+		newsContent := fmt.Sprintf("%s (%s) launches IPO at $%.2f per share. The %s sector welcomes its newest member!",
 			stock.Name, stock.Symbol, stock.CurrentPrice, stock.Sector)
-		
+
 		s.newsService.CreateSystemNews(
 			fmt.Sprintf("%s IPO Launch", stock.Symbol),
 			newsContent,
@@ -578,7 +578,7 @@ func (s *MarketService) ApplySectorEvent(sectorID int, eventType string, impactP
 	if err != nil {
 		return err
 	}
-	
+
 	affectedStocks := 0
 	for _, stock := range stocks {
 		if stock.SectorID != nil && *stock.SectorID == sectorID {
@@ -589,36 +589,46 @@ func (s *MarketService) ApplySectorEvent(sectorID int, eventType string, impactP
 			} else if eventType == "crash" {
 				multiplier = 1 - (impactPercentage / 100)
 			}
-			
+
 			newPrice := stock.CurrentPrice * multiplier
 			if newPrice < 0.01 {
 				newPrice = 0.01
 			}
-			
-			// Update stock price
-			err := s.stockRepo.UpdateStockPrice(stock.ID, newPrice)
-			if err != nil {
+
+			// Update stock price and sync with simulator
+			if err := s.UpdateStockPrice(stock.ID, newPrice); err != nil {
 				log.Printf("Failed to update stock %s during sector event: %v", stock.Symbol, err)
 				continue
 			}
-			
+
 			affectedStocks++
 		}
 	}
-	
+
 	// Create news event
 	sector, _ := s.sectorRepo.GetSectorByID(sectorID)
 	sectorName := "Unknown"
 	if sector != nil {
 		sectorName = sector.Name
 	}
-	
+
 	newsTitle := fmt.Sprintf("%s Sector %s", sectorName, eventType)
-	newsContent := fmt.Sprintf("The %s sector experiences a major %s! %d stocks affected with %.1f%% price impact.", 
+	newsContent := fmt.Sprintf("The %s sector experiences a major %s! %d stocks affected with %.1f%% price impact.",
 		sectorName, eventType, affectedStocks, impactPercentage)
-	
+
 	s.newsService.CreateSystemNews(newsTitle, newsContent, "sector_event", 0, 0)
-	
+
 	log.Printf("Applied %s event to %s sector: %d stocks affected", eventType, sectorName, affectedStocks)
+	return nil
+}
+
+// UpdateStockPrice sets a stock's price and syncs it with the simulator
+func (s *MarketService) UpdateStockPrice(id int, price float64) error {
+	if err := s.stockRepo.UpdateStockPrice(id, price); err != nil {
+		return err
+	}
+	if s.simulator != nil {
+		s.simulator.UpdateStockPrice(id, price)
+	}
 	return nil
 }

--- a/pkg/market/simulation.go
+++ b/pkg/market/simulation.go
@@ -48,12 +48,12 @@ type MarketSimulator struct {
 type StockInfo struct {
 	ID           int
 	Symbol       string
-	Name         string   // Company name for news generation
+	Name         string // Company name for news generation
 	BasePrice    float64
 	Sector       string
 	SectorID     int
-	Trend        float64  // Bias for price movement: positive means upward trend, negative means downward
-	TrendCounter int      // Counter to track trend duration
+	Trend        float64 // Bias for price movement: positive means upward trend, negative means downward
+	TrendCounter int     // Counter to track trend duration
 }
 
 // SectorInfo tracks sector-wide trends and volatility
@@ -68,13 +68,13 @@ type SectorInfo struct {
 // NewMarketSimulator creates a new market simulator
 func NewMarketSimulator(updateInterval time.Duration, volatility float64) *MarketSimulator {
 	return &MarketSimulator{
-		stocksInfo:     make(map[int]StockInfo),
-		sectorsInfo:    make(map[int]SectorInfo),
-		updateInterval: updateInterval,
-		volatility:     volatility,
-		updateChan:     make(chan StockUpdate, 100),
-		stopChan:       make(chan struct{}),
-		pauseChan:      make(chan bool, 1),
+		stocksInfo:        make(map[int]StockInfo),
+		sectorsInfo:       make(map[int]SectorInfo),
+		updateInterval:    updateInterval,
+		volatility:        volatility,
+		updateChan:        make(chan StockUpdate, 100),
+		stopChan:          make(chan struct{}),
+		pauseChan:         make(chan bool, 1),
 		isPaused:          false,
 		newsService:       nil, // Will be set later
 		bankruptcyHandler: nil, // Will be set later
@@ -101,10 +101,10 @@ func (s *MarketSimulator) SetBankruptcyHandler(handler BankruptcyHandlerInterfac
 func (s *MarketSimulator) AddSector(id int, name string, volatilityModifier float64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	// Initialize with a small random trend
-	initialTrend := (rand.Float64() * 0.04) - 0.02  // Range: -0.02 to 0.02
-	
+	initialTrend := (rand.Float64() * 0.04) - 0.02 // Range: -0.02 to 0.02
+
 	s.sectorsInfo[id] = SectorInfo{
 		ID:                 id,
 		Name:               name,
@@ -118,15 +118,15 @@ func (s *MarketSimulator) AddSector(id int, name string, volatilityModifier floa
 func (s *MarketSimulator) AddStock(id int, symbol, name, sector string, sectorID int, basePrice float64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	// Validate base price before adding
 	if math.IsInf(basePrice, 0) || math.IsNaN(basePrice) || basePrice <= 0 {
 		log.Printf("⚠️ Invalid base price for stock %s: %f, setting to $10.00", symbol, basePrice)
 		basePrice = 10.00
 	}
-	
+
 	// Initialize with a random trend (slightly biased upward for a bull market)
-	initialTrend := (rand.Float64() * 0.1) - 0.03  // Range: -0.03 to 0.07, slightly positive bias
+	initialTrend := (rand.Float64() * 0.1) - 0.03 // Range: -0.03 to 0.07, slightly positive bias
 
 	s.stocksInfo[id] = StockInfo{
 		ID:           id,
@@ -138,11 +138,22 @@ func (s *MarketSimulator) AddStock(id int, symbol, name, sector string, sectorID
 		Trend:        initialTrend,
 		TrendCounter: rand.Intn(10) + 5, // Random initial trend duration (5-15 updates)
 	}
-	
+
 	// Update sector stock count
 	if sector, exists := s.sectorsInfo[sectorID]; exists {
 		sector.StockCount++
 		s.sectorsInfo[sectorID] = sector
+	}
+}
+
+// UpdateStockPrice updates a stock's base price in the simulator
+func (s *MarketSimulator) UpdateStockPrice(id int, newPrice float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if info, exists := s.stocksInfo[id]; exists {
+		info.BasePrice = newPrice
+		s.stocksInfo[id] = info
 	}
 }
 
@@ -155,10 +166,10 @@ func (s *MarketSimulator) GetUpdateChannel() <-chan StockUpdate {
 func (s *MarketSimulator) Start() {
 	// Initialize random seed
 	rand.Seed(time.Now().UnixNano())
-	
+
 	log.Printf("🚀 MarketSimulator: Starting market simulation with %d stocks", len(s.stocksInfo))
 	log.Printf("📊 MarketSimulator: Update interval: %v, Volatility: %.2f%%", s.updateInterval, s.volatility*100)
-	
+
 	// Start the simulation loop in a goroutine
 	go s.simulationLoop()
 }
@@ -172,11 +183,11 @@ func (s *MarketSimulator) Stop() {
 func (s *MarketSimulator) simulationLoop() {
 	ticker := time.NewTicker(s.updateInterval)
 	defer ticker.Stop()
-	
+
 	log.Printf("📈 MarketSimulator: Simulation loop started with %v interval", s.updateInterval)
 	updateCount := 0
 	lastLogTime := time.Now()
-	
+
 	for {
 		select {
 		case <-ticker.C:
@@ -185,11 +196,11 @@ func (s *MarketSimulator) simulationLoop() {
 			paused := s.isPaused
 			stockCount := len(s.stocksInfo)
 			s.mu.RUnlock()
-			
+
 			if !paused {
 				updateCount++
 				s.updatePrices()
-				
+
 				// Log progress every 30 seconds
 				if time.Since(lastLogTime) >= 30*time.Second {
 					log.Printf("📊 MarketSimulator: Generated %d updates for %d stocks in last 30s", updateCount, stockCount)
@@ -226,14 +237,14 @@ func (s *MarketSimulator) updateSectorTrends() {
 		if rand.Float64() < 0.1 {
 			adjustment := (rand.Float64() - 0.5) * 0.02 // ±1% change
 			sector.Trend += adjustment
-			
+
 			// Cap sector trends to reasonable limits
 			if sector.Trend > 0.05 {
 				sector.Trend = 0.05
 			} else if sector.Trend < -0.05 {
 				sector.Trend = -0.05
 			}
-			
+
 			s.sectorsInfo[sectorID] = sector
 		}
 	}
@@ -257,18 +268,14 @@ func (s *MarketSimulator) updatePrices() {
 		// Check if we need to change the trend
 		if info.TrendCounter <= 0 {
 			// Time to reverse or modify the trend
-			// Stronger reversal for extreme trends (mean reversion)
-			reversalStrength := 1.0 + math.Abs(info.Trend)*5
 
 			// Generate new trend - more likely to reverse direction
 			if rand.Float64() < 0.7 { // 70% chance of trend reversal
-				// Reverse the trend with some randomness, amplified by reversalStrength
-				info.Trend = -info.Trend * (0.5 + rand.Float64()) * math.Min(reversalStrength, 3.0)
+				// Reverse the trend with a moderate factor to avoid runaway drops
+				info.Trend = -info.Trend * (0.5 + rand.Float64()*0.5) // 50-100% reversal
 			} else {
 				// Modify current trend with dampening (regression to mean)
-				// Stronger dampening for extreme trends
 				dampening := 0.3 + rand.Float64()*0.4 // 30-70% of current trend
-				dampening /= math.Min(reversalStrength, 2.0) // More dampening for extreme trends
 				info.Trend = info.Trend * dampening
 			}
 
@@ -280,17 +287,17 @@ func (s *MarketSimulator) updatePrices() {
 
 		// Calculate price zone volatility based on current price
 		priceZoneVolatility := s.getPriceZoneVolatility(info.BasePrice)
-		
+
 		// Calculate new price with sector correlation
 		// Individual stock factors (70% weight)
 		randomChange := (rand.Float64() - 0.5) * priceZoneVolatility
 		individualChange := randomChange + info.Trend
-		
+
 		// Validate individual change
 		if math.IsInf(individualChange, 0) || math.IsNaN(individualChange) {
 			individualChange = randomChange // fallback to just random change
 		}
-		
+
 		// Sector factors (30% weight)
 		var sectorChange float64
 		if info.SectorID > 0 {
@@ -306,15 +313,15 @@ func (s *MarketSimulator) updatePrices() {
 				}
 			}
 		}
-		
+
 		// Validate sector change
 		if math.IsInf(sectorChange, 0) || math.IsNaN(sectorChange) {
 			sectorChange = 0
 		}
-		
+
 		// Combined change: 70% individual, 30% sector
 		totalChange := (individualChange * 0.7) + (sectorChange * 0.3)
-		
+
 		// Validate total change - cap extreme values
 		if math.IsInf(totalChange, 0) || math.IsNaN(totalChange) {
 			totalChange = 0 // Reset to no change
@@ -323,7 +330,7 @@ func (s *MarketSimulator) updatePrices() {
 		} else if totalChange < -0.5 {
 			totalChange = -0.5
 		}
-		
+
 		// Calculate final price change
 		newPrice := info.BasePrice * (1 + totalChange)
 
@@ -351,7 +358,7 @@ func (s *MarketSimulator) updatePrices() {
 				jumpMultiplier = 1.0 - (rand.Float64() * 0.05) // 0-5% jump down
 			}
 			newPrice *= jumpMultiplier
-			
+
 			// Validate after jump
 			if math.IsInf(newPrice, 0) || math.IsNaN(newPrice) || newPrice <= 0 {
 				newPrice = 0.01
@@ -360,7 +367,7 @@ func (s *MarketSimulator) updatePrices() {
 
 		// Round to 2 decimal places
 		newPrice = math.Round(newPrice*100) / 100
-		
+
 		// Final validation after rounding
 		if math.IsInf(newPrice, 0) || math.IsNaN(newPrice) || newPrice <= 0 {
 			newPrice = 0.01
@@ -381,7 +388,7 @@ func (s *MarketSimulator) updatePrices() {
 			Symbol:  info.Symbol,
 			Price:   newPrice,
 		}
-		
+
 		select {
 		case s.updateChan <- update:
 			// Successfully sent update
@@ -395,16 +402,16 @@ func (s *MarketSimulator) updatePrices() {
 // processCrisisEvent handles bankruptcy/recovery events for stocks at $0.01
 func (s *MarketSimulator) processCrisisEvent(stockID int, stock StockInfo) {
 	log.Printf("🚨 CRISIS EVENT: %s at $0.01 - Rolling for fate...", stock.Symbol)
-	
+
 	// Generate crisis news if this is the first time hitting $0.01
 	// We'll track this better later, for now just generate news occasionally
 	if s.newsService != nil && rand.Float64() < 0.3 { // 30% chance to generate crisis news
 		s.newsService.GenerateCrisisNews(stock.ID, stock.Symbol, stock.Name, stock.Sector)
 	}
-	
+
 	// Crisis event probabilities
 	roll := rand.Float64()
-	
+
 	if roll < 0.05 { // 5% chance of bankruptcy
 		log.Printf("💀 BANKRUPTCY: %s going bankrupt!", stock.Symbol)
 		s.triggerBankruptcy(stockID, stock)
@@ -420,12 +427,12 @@ func (s *MarketSimulator) processCrisisEvent(stockID int, stock StockInfo) {
 // triggerBankruptcy processes a stock bankruptcy event
 func (s *MarketSimulator) triggerBankruptcy(stockID int, stock StockInfo) {
 	log.Printf("📰 NEWS: %s files for bankruptcy - stock delisted", stock.Symbol)
-	
+
 	// Generate bankruptcy news
 	if s.newsService != nil {
 		s.newsService.GenerateBankruptcyNews(stock.ID, stock.Symbol, stock.Name, stock.Sector)
 	}
-	
+
 	// Process bankruptcy with portfolio handling
 	if s.bankruptcyHandler != nil {
 		err := s.bankruptcyHandler.ProcessStockBankruptcy(stockID)
@@ -435,43 +442,43 @@ func (s *MarketSimulator) triggerBankruptcy(stockID int, stock StockInfo) {
 	} else {
 		log.Printf("⚠️ No bankruptcy handler set - portfolio losses not recorded")
 	}
-	
+
 	// Apply sector contagion after processing bankruptcy
 	s.applySectorContagion(stockID, stock, "bankruptcy")
-	
+
 	// Replace the bankrupt company with a new one (simulate new IPO)
 	stock.BasePrice = rand.Float64()*5 + 1 // $1-6 range for "new company"
-	stock.Trend = 0 // Reset trend
+	stock.Trend = 0                        // Reset trend
 	s.stocksInfo[stockID] = stock
-	
+
 	log.Printf("📈 SIMULATION: %s replaced with new company at $%.2f", stock.Symbol, stock.BasePrice)
 }
 
 // triggerRecovery processes a stock recovery event
 func (s *MarketSimulator) triggerRecovery(stockID int, stock StockInfo) {
 	log.Printf("📰 NEWS: Surprise acquisition saves %s!", stock.Symbol)
-	
+
 	// Recovery jump: 10x to 100x potential (1-5 dollar range)
 	recoveryMultiplier := rand.Float64()*400 + 100 // 100x to 500x
 	newPrice := 0.01 * recoveryMultiplier
-	
+
 	// Cap recovery to reasonable range
 	if newPrice > 50 {
 		newPrice = rand.Float64()*30 + 10 // $10-40 range for major recovery
 	}
-	
+
 	// Generate recovery news before updating price
 	if s.newsService != nil {
 		s.newsService.GenerateRecoveryNews(stock.ID, stock.Symbol, stock.Name, stock.Sector, newPrice)
 	}
-	
+
 	stock.BasePrice = newPrice
 	stock.Trend = 0.02 + rand.Float64()*0.03 // Positive trend for a while
-	stock.TrendCounter = rand.Intn(20) + 10 // Longer positive trend
+	stock.TrendCounter = rand.Intn(20) + 10  // Longer positive trend
 	s.stocksInfo[stockID] = stock
-	
+
 	log.Printf("🚀 RECOVERY: %s jumps to $%.2f (%.0fx return!)", stock.Symbol, newPrice, newPrice/0.01)
-	
+
 	// Apply positive sector contagion
 	s.applySectorContagion(stockID, stock, "recovery")
 }
@@ -481,9 +488,9 @@ func (s *MarketSimulator) applySectorContagion(stockID int, stock StockInfo, eve
 	if stock.SectorID == 0 {
 		return // No sector assigned
 	}
-	
+
 	log.Printf("🔗 CONTAGION: Applying %s contagion to %s sector", eventType, stock.Sector)
-	
+
 	contagionCount := 0
 	for id, peerStock := range s.stocksInfo {
 		if id != stockID && peerStock.SectorID == stock.SectorID {
@@ -491,7 +498,7 @@ func (s *MarketSimulator) applySectorContagion(stockID int, stock StockInfo, eve
 			case "bankruptcy":
 				// Major negative impact on sector
 				peerStock.Trend -= 0.05 // Push trend strongly negative
-				
+
 				// Small chance to trigger crisis in vulnerable stocks
 				if peerStock.BasePrice < 10.0 && rand.Float64() < 0.1 {
 					crashAmount := 0.3 + rand.Float64()*0.4 // 30-70% crash
@@ -502,21 +509,21 @@ func (s *MarketSimulator) applySectorContagion(stockID int, stock StockInfo, eve
 					log.Printf("💥 CONTAGION CRASH: %s drops %.0f%% due to sector crisis", peerStock.Symbol, crashAmount*100)
 				}
 				contagionCount++
-				
+
 			case "recovery":
 				// Positive sentiment for sector
 				peerStock.Trend += 0.01 + rand.Float64()*0.02 // 1-3% positive trend
-				peerStock.TrendCounter = rand.Intn(10) + 5 // Short-term boost
+				peerStock.TrendCounter = rand.Intn(10) + 5    // Short-term boost
 				log.Printf("📈 CONTAGION BOOST: %s gets positive sentiment", peerStock.Symbol)
 				contagionCount++
 			}
-			
+
 			s.stocksInfo[id] = peerStock
 		}
 	}
-	
+
 	log.Printf("🔗 CONTAGION: Affected %d stocks in %s sector", contagionCount, stock.Sector)
-	
+
 	// Generate sector contagion news if multiple stocks are affected
 	if contagionCount >= 2 && s.newsService != nil {
 		s.newsService.GenerateSectorContagionNews(stock.Sector, eventType, contagionCount)
@@ -547,18 +554,18 @@ func (s *MarketSimulator) Resume() {
 func (s *MarketSimulator) ReloadStock(stockID int, newPrice float64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	if stock, exists := s.stocksInfo[stockID]; exists {
 		// Validate and set new price
 		if math.IsInf(newPrice, 0) || math.IsNaN(newPrice) || newPrice <= 0 {
 			newPrice = 0.01
 		}
 		stock.BasePrice = newPrice
-		
+
 		// Reset trend to prevent carrying over corrupted values
 		stock.Trend = 0
 		stock.TrendCounter = rand.Intn(10) + 5
-		
+
 		s.stocksInfo[stockID] = stock
 	}
 }
@@ -567,22 +574,22 @@ func (s *MarketSimulator) ReloadStock(stockID int, newPrice float64) {
 func (s *MarketSimulator) ValidateAllStocks() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	for id, stock := range s.stocksInfo {
 		fixed := false
-		
+
 		// Fix invalid base prices
 		if math.IsInf(stock.BasePrice, 0) || math.IsNaN(stock.BasePrice) || stock.BasePrice <= 0 {
 			stock.BasePrice = 0.01
 			fixed = true
 		}
-		
+
 		// Fix invalid trends
 		if math.IsInf(stock.Trend, 0) || math.IsNaN(stock.Trend) {
 			stock.Trend = 0
 			fixed = true
 		}
-		
+
 		// Cap extreme trends
 		if stock.Trend > 0.1 {
 			stock.Trend = 0.1
@@ -591,7 +598,7 @@ func (s *MarketSimulator) ValidateAllStocks() {
 			stock.Trend = -0.1
 			fixed = true
 		}
-		
+
 		if fixed {
 			s.stocksInfo[id] = stock
 			log.Printf("Fixed corrupted stock data for %s: price=%.2f, trend=%.4f", stock.Symbol, stock.BasePrice, stock.Trend)
@@ -605,22 +612,22 @@ func (s *MarketSimulator) ValidateAllStocks() {
 func (s *MarketSimulator) ForceCrisisEvent(stockID int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	stock, exists := s.stocksInfo[stockID]
 	if !exists {
 		return fmt.Errorf("stock with ID %d not found", stockID)
 	}
-	
+
 	log.Printf("🧪 TESTING: Forcing crisis event for %s", stock.Symbol)
-	
+
 	// Set stock to crisis price
 	stock.BasePrice = 0.01
 	stock.Trend = -0.05 // Strong negative trend
 	s.stocksInfo[stockID] = stock
-	
+
 	// Trigger crisis event processing
 	s.processCrisisEvent(stockID, stock)
-	
+
 	// Send price update
 	select {
 	case s.updateChan <- StockUpdate{
@@ -631,7 +638,7 @@ func (s *MarketSimulator) ForceCrisisEvent(stockID int) error {
 	default:
 		// Channel full, skip update
 	}
-	
+
 	return nil
 }
 
@@ -639,21 +646,21 @@ func (s *MarketSimulator) ForceCrisisEvent(stockID int) error {
 func (s *MarketSimulator) ForceBankruptcy(stockID int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	stock, exists := s.stocksInfo[stockID]
 	if !exists {
 		return fmt.Errorf("stock with ID %d not found", stockID)
 	}
-	
+
 	log.Printf("🧪 TESTING: Forcing bankruptcy for %s", stock.Symbol)
-	
+
 	// Set to crisis price first
 	stock.BasePrice = 0.01
 	s.stocksInfo[stockID] = stock
-	
+
 	// Trigger bankruptcy directly
 	s.triggerBankruptcy(stockID, stock)
-	
+
 	return nil
 }
 
@@ -661,21 +668,21 @@ func (s *MarketSimulator) ForceBankruptcy(stockID int) error {
 func (s *MarketSimulator) ForceRecovery(stockID int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	stock, exists := s.stocksInfo[stockID]
 	if !exists {
 		return fmt.Errorf("stock with ID %d not found", stockID)
 	}
-	
+
 	log.Printf("🧪 TESTING: Forcing recovery for %s", stock.Symbol)
-	
+
 	// Set to crisis price first
 	stock.BasePrice = 0.01
 	s.stocksInfo[stockID] = stock
-	
+
 	// Trigger recovery directly
 	s.triggerRecovery(stockID, stock)
-	
+
 	return nil
 }
 
@@ -683,7 +690,7 @@ func (s *MarketSimulator) ForceRecovery(stockID int) error {
 func (s *MarketSimulator) GetStockInfo(stockID int) (StockInfo, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	
+
 	stock, exists := s.stocksInfo[stockID]
 	return stock, exists
 }
@@ -692,7 +699,7 @@ func (s *MarketSimulator) GetStockInfo(stockID int) (StockInfo, bool) {
 func (s *MarketSimulator) ListAllStocks() map[int]StockInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	
+
 	// Return a copy to avoid race conditions
 	result := make(map[int]StockInfo)
 	for id, stock := range s.stocksInfo {
@@ -736,12 +743,12 @@ func (s *MarketSimulator) ProcessTransaction(stockID int, quantity int, isBuy bo
 
 	// Calculate new price
 	newPrice := stock.BasePrice * (1 + impactFactor)
-	
+
 	// Validate the calculated price
 	if math.IsInf(newPrice, 0) || math.IsNaN(newPrice) || newPrice <= 0 {
 		newPrice = 0.01
 	}
-	
+
 	if newPrice < 0.01 {
 		newPrice = 0.01
 	} else if newPrice > 1000000 { // Cap at $1M per share

--- a/tests/crisis_integration_test.go
+++ b/tests/crisis_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"officestonks/internal/models"
 	"officestonks/internal/repository"
 	"officestonks/internal/services"
-	"officestonks/pkg/market"
 )
 
 // TestCrisisMechanics tests the complete crisis/bankruptcy/recovery flow


### PR DESCRIPTION
## Summary
- keep simulator in sync when admins or sector events update stock prices
- add simulator method to update stock price and soften trend reversals to avoid runaway price drops

## Testing
- `go test ./...` *(fails: `tests/crisis_integration_test.go:12:2: "officestonks/pkg/market" imported and not used`)*

------
https://chatgpt.com/codex/tasks/task_e_689633a5ffe4833180019ad57952c36a