### PR TITLE
fix: harden message sanitization

### DIFF
--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -32,9 +32,10 @@ const (
 
 // Regex patterns
 var (
-	usernameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
-	emailRegex    = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
-	sqlPattern    = regexp.MustCompile(`(?i)(union|select|insert|update|delete|drop|create|alter|exec|script|javascript|<script|onload|onerror)`)
+	usernameRegex   = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+	emailRegex      = regexp.MustCompile(`^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`)
+	protocolPattern = regexp.MustCompile(`(?i)(javascript|data):`)
+	sqlPattern      = regexp.MustCompile(`(?i)(union|select|insert|update|delete|drop|create|alter|exec|script|javascript|<script|onload|onerror)`)
 )
 
 // ValidateUsername validates a username
@@ -172,8 +173,7 @@ func SanitizeString(input string) string {
 	// Remove any remaining potentially dangerous content
 	sanitized = strings.ReplaceAll(sanitized, "<", "&lt;")
 	sanitized = strings.ReplaceAll(sanitized, ">", "&gt;")
-	sanitized = strings.ReplaceAll(sanitized, "javascript:", "")
-	sanitized = strings.ReplaceAll(sanitized, "data:", "")
+	sanitized = protocolPattern.ReplaceAllString(sanitized, "")
 
 	return sanitized
 }

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeStringRemovesJavascriptProtocol(t *testing.T) {
+	input := "Check this link: JavaScript:alert('xss')"
+	sanitized := SanitizeString(input)
+	if strings.Contains(strings.ToLower(sanitized), "javascript:") {
+		t.Fatalf("sanitized string still contains javascript protocol: %q", sanitized)
+	}
+}
+
+func TestSanitizeStringRemovesDataProtocol(t *testing.T) {
+	input := "Embedded data: DATA:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="
+	sanitized := SanitizeString(input)
+	if strings.Contains(strings.ToLower(sanitized), "data:") {
+		t.Fatalf("sanitized string still contains data protocol: %q", sanitized)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent case-insensitive `javascript:`/`data:` protocol bypasses when sanitizing messages
- test message sanitization against dangerous protocols

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b532cc62c83319cca2ed67536e5e1